### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -49,3 +49,15 @@ PID    | Product name
 0x8041 | ESPattoZero CPY-KIT
 0x8042 | ESPattoZero NUTTX-KIT
 0x8043 | ESPattoZero DIY-KIT
+0x8044 | ESPattoZero USB-CTM16
+0x8045 | ESPattoZero USB-CTM32
+0x8046 | ESPattoZero USB-CTM64
+0x8047 | ESPattoZero USB-CTM128
+0x8048 | ESPattoZero USB-MTC16
+0x8049 | ESPattoZero USB-MTC32
+0x804A | ESPattoZero USB-MTC64
+0x804B | ESPattoZero USB-MTC128
+0x804C | ESPattoZero CTM PRO
+0x804D | ESPattoZero MTC PRO
+0x804E | ESPattoZero VCP2WiFi
+0x804F | ESPattoZero EIA-485

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -46,3 +46,6 @@ PID    | Product name
 0x803E | ESPattoZero Health&Fitnees minder  
 0x803F | ESPattoZero DAW-PRO
 0x8040 | ESPattoZero V-bridge
+0x8041 | ESPattoZero CPY-KIT
+0x8042 | ESPattoZero NUTTX-KIT
+0x8043 | ESPattoZero DIY-KIT

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -6,3 +6,9 @@ registering the PID for (e.g. My Widget Company touch-free WiFi USB keyboard)
 
 PID    | Product name
 0x8000 | Espressif test PID
+0x801A | ESPattoZero CircuitS
+0x801B | ESPattoZero Engineering Base
+0x801C | ESPattoZero Test fixture
+0x801D | ESPattozero Logic Analyzer
+0x801E | ESPattoZero Board Tester
+0x801F | ESPattoZero Air quality tester

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -32,7 +32,7 @@ PID    | Product name
 0x8031 | ESPattoZero USB-MIDI64
 0x8031 | ESPattoZero USB-MIDI128
 0x8032 | ESPattoZero DMX-BASE-HOME
-0x8033 | ESPattpZero DMX-BASE-PRO
+0x8033 | ESPattoZero DMX-BASE-PRO
 0x8034 | ESPattoZero B4A-Connect
 0x8035 | ESPattoZero Android-Bridge
 0x8036 | ESPattoZero CINEMA-SCOPE-IT

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -12,3 +12,37 @@ PID    | Product name
 0x801D | ESPattozero Logic Analyzer
 0x801E | ESPattoZero Board Tester
 0x801F | ESPattoZero Air quality tester
+0x8020 | ESPattoZero X-ThermalPro
+0x8021 | ESPattoZero SECureCAM 
+0x8022 | ESPattoZero StampIT
+0x8023 | ESPattoZero Signalgenerator
+0x8024 | ESPattoZero SnapONzero
+0x8025 | ESPattoZero SnapONmini
+0x8026 | ESPattoZero espKIT Home
+0x8027 | ESPattoZero espKIT Mobil
+0x8028 | ESPattoZero LoRa-X-Home
+0x8029 | ESPattoZero LoRa-X-Mobil
+0x802A | ESPattoZero C3-MINI-Modul-ADD
+0x802B | ESPattoZero C3-WROOM-Modul-ADD
+0x802C | ESPattoZero S2-MINI-Modul-ADD
+0x802D | ESPattoZero S2-WROOM-Modul-ADD
+0x802E | ESPattoZero S2-WROVER-Modul-ADD
+0x802F | ESPattoZero GBRL-DONGLE
+0x8030 | ESPattoZero USB-MIDI32
+0x8031 | ESPattoZero USB-MIDI64
+0x8031 | ESPattoZero USB-MIDI128
+0x8032 | ESPattoZero DMX-BASE-HOME
+0x8033 | ESPattpZero DMX-BASE-PRO
+0x8034 | ESPattoZero B4A-Connect
+0x8035 | ESPattoZero Android-Bridge
+0x8036 | ESPattoZero CINEMA-SCOPE-IT
+0x8037 | ESPattoZero MINI-SCOPE-IT
+0x8038 | ESPattoZero Smart-Homeoffice 
+0x8039 | ESPattoZero X-LINK
+0x803A | ESPattoZero BION-ELV 
+0x803B | ESPattoZero EMU-x-
+0x803C | ESPattoZero Switch-TH-ing
+0x803D | ESPattoZero VFM vehicle fleet manager
+0x803E | ESPattoZero Health&Fitnees minder  
+0x803F | ESPattoZero DAW-PRO
+0x8040 | ESPattoZero V-bridge


### PR DESCRIPTION
last entry from last request list was 0x8019...
using next available PID..



0x801A | ESPattoZero CircuitS
--------------------------------------------------------------------------------

    A short description of what the device is going to do 
desc: usb-device with expanded customized functions for connecting Circuits 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x801B | ESPattoZero Engineering Base
--------------------------------------------------------------------------------

    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for engineering and testing  

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero






0x801C | ESPattoZero Test fixture
--------------------------------------------------------------------------------

    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a test fixture 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero







0x801D | ESPattoZero Logic Analyzer
--------------------------------------------------------------------------------

    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Logic Analyzer 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero







0x801E | ESPattoZero Board Tester
--------------------------------------------------------------------------------

    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for production testing board  

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero








0x801F | ESPattoZero Air quality tester
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Air quality tester 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero




0x8020 | ESPattoZero X-ThermalPro
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Thermal  

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8021 | ESPattoZero SECureCAM 
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a security camera 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8022 | ESPattoZero StampIT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a miniature esp module with expand function 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8023 | ESPattoZero Signalgenerator
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Signal Generator 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8024 | ESPattoZero SnapONzero
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a snap on device zero factor 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8025 | ESPattoZero SnapONmini
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a snap on device mini factor 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8026 | ESPattoZero espKIT Home
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a esp KIT for connecting things at HOME 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8027 | ESPattoZero espKIT Mobil
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a esp KIT for connecting things Mobile 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8028 | ESPattoZero LoRa-X-Home
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a LoRa Base for Home

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8029 | ESPattoZero LoRa-X-Mobil
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a LoRa Base for Mobile

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802A | ESPattoZero C3-MINI-Modul-ADD
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a ESP32-C3-MINI Modul for connect it

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-C3 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802B | ESPattoZero C3-WROOM-Modul-ADD
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a ESP32-C3-WROOM Modul for connect it 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-C3 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802C | ESPattoZero S2-MINI-Modul-ADD
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a ESP32-S2-MINI Modul for connect it

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802D | ESPattoZero S2-WROOM-Modul-ADD
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a ESP32-S2-WROOM Modul for connect it

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802E | ESPattoZero S2-WROVER-Modul-ADD
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a ESP32-S2-WROVER Modul for connect it 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x802F | ESPattoZero GBRL-DONGLE
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a GBRL Dongle

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8030 | ESPattoZero USB-MIDI32
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB MIDI32 device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8031 | ESPattoZero USB-MIDI64
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB MIDI64 device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8031 | ESPattoZero USB-MIDI128
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB MIDI128 device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8032 | ESPattoZero DMX-BASE-HOME
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a DMX-Base HOME device  

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8033 | ESPattoZero DMX-BASE-PRO
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a DMX-Base PRO device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8034 | ESPattoZero B4A-Connect
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a B4A Dongle to connect for Developing and more

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8035 | ESPattoZero Android-Bridge
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Android Bridge between Things, PC and Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8036 | ESPattoZero CINEMA-SCOPE-IT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a CINEMA SCOPE device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8037 | ESPattoZero MINI-SCOPE-IT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a MINI SCOPE device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8038 | ESPattoZero Smart-Homeoffice 
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Smart-Homeoffice DONGLE

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8039 | ESPattoZero X-LINK
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a X-LINK device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803A | ESPattoZero BION-ELV 
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a BION Sensoric Board

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803B | ESPattoZero EMU-x-
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a EMU device 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803C | ESPattoZero Switch-TH-ing
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Switching Board Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803D | ESPattoZero VFM vehicle fleet manager
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Management to vehicle fleet

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803E | ESPattoZero Health&Fitnees minder  
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a Health&Fitnes minder board with sensoric

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x803F | ESPattoZero DAW-PRO
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a DAW Pro device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero





0x8040 | ESPattoZero V-bridge
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a V-bridge to connect device/board to HOST/PC

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero



0x8041 | ESPattoZero CPY-KIT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a CPY-KIT device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero




0x8042 | ESPattoZero NUTTX-KIT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a NUTTX-KIT device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero




0x8043 | ESPattoZero DIY-KIT
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a DIY-KIT device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero



0x8044 | ESPattoZero USB-CTM16
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-CTM16 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x8045 | ESPattoZero USB-CTM32
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-CTM32 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x8046 | ESPattoZero USB-CTM64
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-CTM64 Device 

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x8047 | ESPattoZero USB-CTM128
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-CTM128 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x8048 | ESPattoZero USB-MTC16
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-MTC16 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x8049 | ESPattoZero USB-MTC32
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-MTC32 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804A | ESPattoZero USB-MTC64
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-MTC64 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804B | ESPattoZero USB-MTC128
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a USB-MTC128 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804C | ESPattoZero CTM PRO
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a CTM PRO Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804D | ESPattoZero MTC PRO
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a MTC PRO Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804E | ESPattoZero VCP2WiFi
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a VCP2WiFi Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero


0x804F | ESPattoZero EIA-485
--------------------------------------------------------------------------------
    A short description of what the device is going to do 
desc: usb-device base with expanded customized functions for a EIA-485 Device

    What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
chips: ESP32-S2, ESP32-C3, ESP32-S3 ( ESP32-S4 if it supports USB ) 

    Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
 why: a custom USB class on ESP32 is used and needs a non-standard driver on the host

    If you're requesting a PID on behalf of a company, please mention the name of the company
ESPattoZero TM

    If applicable/available, a website or other URL with information about your product or company
https://github.com/ESPattoZero




