### PR TITLE
Request PIDS for my new TinyS2 ESP32-S2 development board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -6,4 +6,5 @@ registering the PID for (e.g. My Widget Company touch-free WiFi USB keyboard)
 
 PID    | Product name
 0x8000 | Espressif test PID
-0x8001 | Unexpected Maker TinyS2
+0x8001 | Unexpected Maker TinyS2 - Arduino
+0x8002 | Unexpected Maker TinyS2 - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -6,3 +6,4 @@ registering the PID for (e.g. My Widget Company touch-free WiFi USB keyboard)
 
 PID    | Product name
 0x8000 | Espressif test PID
+0x8001 | Unexpected Maker TinyS2


### PR DESCRIPTION
I'm after 2x PIDs for my new TinyS2 development board using the new ESP32-S2FN4R2. One for Arduino/IDF and one for CircuitPython as the TinyS2 will be only using the native USB.

Btw, thanks HEAPS for making PIDs available - It's very generous and a huge help for small companies like mine that only do a few boards every year. 

Reason for custom PIDs are: 

**CircuitPython** - Adafruit require every board that runs CircuitPython to have a unique PID

**Arduino** - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my TinyS2 would show up as TinyS2 instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, **Unexpected Maker** and though I don't have online info for my TinyS2 yet, here are some links for my other ESP32 based boards:

TinyPICO (ESP32-PICO-D4) -[https://tinypico.com]( https://tinypico.com)
FeatherS2 (ESP32-S2) - [https://feathers2.io](https://feathers2.io)
And more about Unexpected Maker - [https://unexpectedmaker.com](https://unexpectedmaker.com)