### PR TITLE
Requested PIDs for upcoming Wualabs - Wuard.io USB crypto devices

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -8,3 +8,5 @@ PID    | Product name
 0x8000 | Espressif test PID
 0x8001 | Unexpected Maker TinyS2 - Arduino
 0x8002 | Unexpected Maker TinyS2 - CircuitPython
+0x8003 | Wualabs - Wuard Zero - Vera crypto dev board
+0x8004 | Wualabs - Wuard crypto


### PR DESCRIPTION
Desc: USB Crypto devices for development and security applications
Chip: ESP32-S2FH4
Why: For security reasons a dedicated PID adds extra checkpoints for the software in the host
Company: Wualabs LTD (https://wualabs.com)
