### PR TITLE
Added extra PID for UF2 Bootloader

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -10,3 +10,4 @@ PID    | Product name
 0x8002 | Unexpected Maker TinyS2 - CircuitPython
 0x8003 | Wualabs - Wuard Zero - Vera crypto dev board
 0x8004 | Wualabs - Wuard crypto
+0x8005 | Unexpected Maker TinyS2 - UF2 Bootloader


### PR DESCRIPTION
Sorry, It seems I need a 3rd PID for my TinyS2 as the UF2 bootloader also requires a unique PID for the USB device when it boots as a mass storage device. TinyUF2 doesn't allow sharing of PIDs here.