### PR TITLE
Requesting PIDs for LILYGO TTGO T8 ESP32-S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -1,7 +1,7 @@
 Allocated PIDs under Espressifs VID (0x303a). When adding a PID, please take
-the next available one and add it at the bottom of the list, in order to keep 
+the next available one and add it at the bottom of the list, in order to keep
 the list sequential. For a product name, please include both the name of your
-company (or your own name or nickname) and the name of the device you're 
+company (or your own name or nickname) and the name of the device you're
 registering the PID for (e.g. My Widget Company touch-free WiFi USB keyboard)
 
 PID    | Product name
@@ -11,3 +11,6 @@ PID    | Product name
 0x8003 | Wualabs - Wuard Zero - Vera crypto dev board
 0x8004 | Wualabs - Wuard crypto
 0x8005 | Unexpected Maker TinyS2 - UF2 Bootloader
+0x8006 | LILYGO TTGO T8 ESP32-S2 - Arduino
+0x8007 | LILYGO TTGO T8 ESP32-S2 - CircuitPython
+0x8008 | LILYGO TTGO T8 ESP32-S2 - UF2 Bootloader


### PR DESCRIPTION
[This board](http://www.lilygo.cn/prod_view.aspx?id=1321) by LILYGO seems like a great option for someone to start tinkering with ESP32-S2.  
But, unfortunately the board manufacturer [does not have a USB VID](https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2/issues/4).

I have [added support for CircuitPython for this board](https://github.com/adafruit/circuitpython/pull/3943), but to be able to get that merged, I need two unique and valid PIDs for this board. One for CircuitPython itself, and another for the UF2 bootloader (for when it boots up in mass-storage mode).

Also, Thanks a lot for offering these PIDs, they are an invaluable resource for open-source software.
Cheers