### PR TITLE
Added PIDs for the ATMegaZero ESP32-S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -15,5 +15,5 @@ PID    | Product name
 0x8007 | LILYGO TTGO T8 ESP32-S2 - CircuitPython
 0x8008 | LILYGO TTGO T8 ESP32-S2 - UF2 Bootloader
 0x8009 | ATMegaZero ESP32-S2 - CircuitPython
-0x8010 | ATMegaZero ESP32-S2 - Arduino
-0x8011 | ATMegaZero ESP32-S2 - UF2 Bootloader
+0x800A | ATMegaZero ESP32-S2 - Arduino
+0x800B | ATMegaZero ESP32-S2 - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -14,3 +14,6 @@ PID    | Product name
 0x8006 | LILYGO TTGO T8 ESP32-S2 - Arduino
 0x8007 | LILYGO TTGO T8 ESP32-S2 - CircuitPython
 0x8008 | LILYGO TTGO T8 ESP32-S2 - UF2 Bootloader
+0x8009 | ATMegaZero ESP32-S2 - CircuitPython
+0x8010 | ATMegaZero ESP32-S2 - Arduino
+0x8011 | ATMegaZero ESP32-S2 - UF2 Bootloader


### PR DESCRIPTION
I would love to use 3 PIDs for my new development board “ATMegaZero ESP32-S2” which uses the new ESP32-S2 chip.

**Reason for custom PIDs are:**

**CircuitPython -** Adafruit require every board that runs CircuitPython to have a unique PID

**Arduino -** In order to use a custom board on the Arduino IDE the board definition requires a unique PID to identify the board by its name. I would love to be able to display the board as “ATMegaZero ESP32-S2” and not with a generic USB name.

**UF2 Bootloader -** UF2 bootloader requires a unique PID for the USB device when it boots as a mass storage device.

I am requesting these PIDs on behalf of my own company EspinalLab, LLC. You can find the first version of the ATMegaZero at [www.atmegazero.com](https://atmegazero.com).  The new board is not posted on the site yet, but you can find photos and videos on my Twitter or Instagram channel [https://twitter.com/4hackrr/status/1353854084290387969](https://twitter.com/4hackrr/status/1353854084290387969) & [https://instagram.com/4hackrr](https://instagram.com/4hackrr)

Thanks in advance for accepting my request.
Eddie Espinal