### PR TITLE
USB PIDS for Gravitech Cucumber RIS board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -17,3 +17,6 @@ PID    | Product name
 0x8009 | ATMegaZero ESP32-S2 - CircuitPython
 0x800A | ATMegaZero ESP32-S2 - Arduino
 0x800B | ATMegaZero ESP32-S2 - UF2 Bootloader
+0x800C | GRAVITECH CUCUMBER RIS ESP32S2 - Arduino
+0x800D | GRAVITECH CUCUMBER RIS ESP32S2 - CircuitPython
+0x800E | GRAVITECH CUCUMBER RIS ESP32S2 - UF2 Bootloader


### PR DESCRIPTION
Can you allocate USB PIDS for the following board.

PIDs required:  Arduino, Circuitpython, UF2 Bootloader
Board: Gravitech Cucumber RIS
Processor: ESP32S2
Adafruit requires unique USB PIDs for all circuitpyython boards. 
https://www.gravitech.us/cursdebowise.html

Thanks, 