### PR TITLE
Added PID for ESPattoZero™ ...

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -21,3 +21,147 @@ PID    | Product name
 0x800D | GRAVITECH CUCUMBER RIS ESP32S2 - CircuitPython
 0x800E | GRAVITECH CUCUMBER RIS ESP32S2 - UF2 Bootloader
 0x800F | Troo - FarmTRX Yield Monitor
+0x8010 | ESP32DE Stickley-MIDI-PRO
+0x8011 | ESP32DE Stickley-Arduino
+0x8012 | ESP32DE Stickley-UF2-Bootloader
+0x8013 | ESP32DE Stickley-CircuitPython
+0x8014 | ESP32DE WiFi-CAN-Bridge-PRO
+0x8015 | ESP32DE WiFi-OTG-Bridge-PRO
+0x8016 | ESP32DE WiFi-MCU-Bridge-PRO
+0x8017 | ESP32DE LIVE-STYLER-PRO 
+0x8018 | ESP32DE STICKLEY-PRO
+0x8019 | ESP32DE MCU-Commander
+0x801A | ESP32DE -A-TESTDRIVE
+0x801B | ESP32DE -B-TESTHOST
+0x801C | ESP32DE -C-TESTDEVICE
+0x801D | ESP32DE -D-NEURONAL
+0x801E | ESP32DE -E-REMOTE
+0x801F | ESP32DE -F-OSZ 
+0x8020 | ESP32DE PSRAMBANK-PRO
+0x8021 | ESP32DE WiFi-DONGLE
+0x8022 | ESP32DE PeripheralBridge
+0x8023 | ESP32DE SIMEPI™ DONGLE
+0x8024 | ESP32DE AIoT-DONGLE
+0x8025 | ESP32DE IoT-DONGLE
+0x8026 | ESP32DE WEBUSB-PRO
+0x8027 | ESP32DE TINY-SHinY
+0x8028 | ESP32DE devflowcharter PRO
+0x8029 | ESP32DE WEBSPI-PRO
+0x802A | ESPattoZero™ CircuitS
+0x802B | ESPattoZero™ Engineering
+0x802C | ESPattoZero™ Test fixture
+0x802D | ESPattozero™ Logic Analyzer
+0x802E | ESPattoZero™ Board Tester
+0x802F | ESPattoZero™ Air quality tester
+0x8030 | ESPattoZero™ X-ThermalPro
+0x8031 | ESPattoZero™ SECureCAM 
+0x8032 | ESPattoZero™ StampIT
+0x8033 | ESPattoZero™ Signalgenerator
+0x8034 | ESPattoZero™ SnapSONzero
+0x8035 | ESPattoZero™ SnapSONmini
+0x8036 | ESPattoZero™ espKIT Home
+0x8037 | ESPattoZero™ espKIT Mobil
+0x8038 | ESPattoZero™ LoRa-X-Home
+0x8039 | ESPattoZero™ LoRa-X-Mobil
+0x803A | ESPattoZero™ ZERO-UF2-Bootloader
+0x803B | ESPattoZero™ ZERO-CircuitPython
+0x803C | ESPattoZero™ ZERO-Arduino 
+0x803D | ESPattoZero™ SIMEPI™-Arduino 
+0x803E | ESPattoZero™ RODI™-Arduino
+0x803F | ESPattoZero™ GBRL-DONGLE
+0x8040 | ESPattoZero™ USB-MIDI32
+0x8041 | ESPattoZero™ USB-MIDI64
+0x8042 | ESPattoZero™ USB-MIDI128
+0x8043 | ESPattoZero™ DMX-BASE-HOME
+0x8044 | ESPattpZero™ DMX-BASE-PRO
+0x8045 | ESPattoZero™ B4A-Connect
+0x8046 | ESPattoZero™ Android-Bridge
+0x8047 | ESPattoZero™ CINEMA-SCOPE-IT
+0x8048 | ESPattoZero™ MINI-SCOPE-IT
+0x8049 | ESPattoZero™ X-LINK
+0x804A | ESPattoZero™ BION-ELV 
+0x804B | ESPattoZero™ EMU-x-
+0x804C | ESPattoZero™ Switch-TH-ing
+0x804D | ESPattoZero™ VFM vehicle fleet manager
+0x804E | ESPattoZero™ Health&Fitnees minder  
+0x804F | ESPattoZero™ DAW-PRO
+0x8050 | ESPattoZero™ V-bridge
+0x8051 | ESPattoZero™ CPY-KIT
+0x8052 | ESPattoZero™ NUTTX-KIT
+0x8053 | ESPattoZero™ DIY-KIT
+0x8054 | ESPattoZero™ USB-CTM16
+0x8055 | ESPattoZero™ USB-CTM32
+0x8056 | ESPattoZero™ USB-CTM64
+0x8057 | ESPattoZero™ USB-CTM128
+0x8058 | ESPattoZero™ USB-MTC16
+0x8059 | ESPattoZero™ USB-MTC32
+0x805A | ESPattoZero™ USB-MTC64
+0x805B | ESPattoZero™ USB-MTC128
+0x805C | ESPattoZero™ CTM PRO
+0x805D | ESPattoZero™ MTC PRO
+0x805E | ESPattoZero™ VCP2WiFi
+0x805F | ESPattoZero™ EIA-485
+0x8060 | ESPattoZero™ ESPattoZero-cero
+0x8061 | ESPattoZero™ ESPattoZero-uno
+0x8062 | ESPattoZero™ ESPattoZero-dos
+0x8063 | ESPattoZero™ ESPattoZero-tres
+0x8064 | ESPattoZero™ ESPattoZero-cuatro
+0x8065 | ESPattoZero™ ESPattoZero-cinco
+0x8066 | ESPattoZero™ ESPattoZero-seis
+0x8067 | ESPattoZero™ ESPattoZero-siete
+0x8068 | ESPattoZero™ ESPattoZero-ocho
+0x8069 | ESPattoZero™ ESPattoZero-nueve
+0x806A | ESPattoZero™ PICOio-UF2
+0x806B | ESPattoZero™ PICOio-CircuitPython
+0x806C | ESPattoZero™ PICOio-Arduino
+0x806D | ESPattoZero™ PICOio-PRO-UF2
+0x806E | ESPattoZero™ PICOio-PRO-CircuitPython
+0x806F | ESPattoZero™ PICOio-PRO-Arduino
+0x8070 | ESPattoZero™ ATTO-UF2
+0x8071 | ESPattoZero™ ATTO-CircuitPython
+0x8072 | ESPattoZero™ ATTO-Arduino
+0x8073 | ESPattoZero™ ATTO-PRO-UF2
+0x8074 | ESPattoZero™ ATTO-PRO-CircuitPython
+0x8075 | ESPattoZero™ ATTO-PRO-Arduino
+0x8076 | ESPattoZero™ MAMAMIA-UF2
+0x8077 | ESPattoZero™ MAMAMIA-CircuitPython
+0x8078 | ESPattoZero™ MAMAMIA-Arduino
+0x8079 | ESPattoZero™ LEONPI-MSI-PRO
+0x807A | ESPattoZero™ LEONPI-MSI-UF2
+0x807B | ESPattoZero™ LEONPI-MSI-CircuitPython
+0x807C | ESPattoZero™ LEONPI-MSI-Arduino
+0x807D | ESPattoZero™ GeoTracking Station
+0x807E | ESPattoZero™ GeoTracking Base
+0x807F | ESPattoZero™ GeoTracking Mobil
+0x8080 | ESPattoZero™ PROXY-NET
+0x8081 | ESPattoZero™ PORT-NET
+0x8082 | ESPattoZero™ Studentenwerk Station
+0x8083 | ESPattoZero™ Studentenwerk Client
+0x8084 | ESPattoZero™ Studentenwerk Mobil
+0x8085 | ESPattoZero™ Studentenwerk YESAR
+0x8086 | ESPattoZero™ UNI VM-iAPX 86
+0x8087 | ESPattoZero™ UNI VM-x87 floating-point
+0x8088 | ESPattoZero™ UNI VM-8088
+0x8089 | ESPattoZero™ UNI VM-DMA
+0x808A | ESPattoZero™ Freifunk S2 Bridge
+0x808B | ESPattoZero™ Voltamere PI Station
+0x808C | ESPattoZero™ Voltamere PI Client
+0x808D | ESPattoZero™ Voltamere PI Mobil
+0x808E | ESPattoZero™ Voltamere PI YESAR
+0x808F | ESPattoZero™ GPS NMEA Locater
+0x8090 | ESPattoZero™ GPS NMEA FOX
+0x8091 | ESPattoZero™ GPS NMEA HUNTER
+0x8092 | ESPattoZero™ GPS NMEA Base
+0x8093 | ESPattoZero™ GPS NMEA Station
+0x8094 | ESPattoZero™ GPS NMEA Mobil
+0x8095 | ESPattoZero™ GPS NMEA YESAR
+0x8096 | ESPattoZero™ NMEA Monitor
+0x8097 | ESPattoZero™ USB Reminder
+0x8098 | ESPattoZero™ USB TrackingStar
+0x8099 | ESPattoZero™ USB Router
+0x809A | ESPattoZero™ USB-INK 
+0x809B | ESPattoZero™ HOMESCHOOLING
+0x809C | ESPattoZero™ UNI-VM-A7150-ROB-VEB
+0x809D | ESPattoZero™ UNI-VM-DCP1700-ROB-VEB
+0x809E | ESPattoZero™ UNI-VM-DCP-GX-ROB-VEB
+0x809F | ESPattoZero™ USB WIFI-HOTSPOT

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -68,7 +68,7 @@ PID    | Product name
 0x803C | ESPattoZero™ ZERO-Arduino 
 0x803D | ESPattoZero™ SIMEPI™-Arduino 
 0x803E | ESPattoZero™ RODI™-Arduino
-0x803F | ESPattoZero™ GBRL-DONGLE
+0x803F | ESPattoZero™ GRBL-DONGLE
 0x8040 | ESPattoZero™ USB-MIDI32
 0x8041 | ESPattoZero™ USB-MIDI64
 0x8042 | ESPattoZero™ USB-MIDI128


### PR DESCRIPTION
... and ESP32DE.



thank you for offer the option of using a PID allocated under the Espressif VID.

**_custom PIDs cases are:_**

**_UF2 / UF2-Bootloader_** - requires a unique PID for the USB device when it boots as a mass storage device. 
TinyUF2 doesn't allow sharing of PIDs here.

**_CircuitPython_** - _Adafruit_ require every board that runs CircuitPython to have a unique PID

**_Arduino_** - a unique PID allows the board to be listed by Board Name instead of "generic ESP32 dev board"

**_USB Boards / Dongle_** need a unique **PID** cause the Desktop / Mobile Software which works for **identify** the Device on the **PID** and load the specific driver for it to communicate with it.


**_"More Background"_**
_**At first glance, it looks by used Device Names, as if standard classes are involved. the following explanation:**_
As with the UF2 boot loader, a standard class ( MASS Storage ) is used by a **distinctive PID as INDEX / unique detection**. I use the PID **as a unique identifier**. The device does not work with standard class and **requires a special (firmware)** driver, which is provided by me. For **_enumeration and identify in the system_** and with more devices - in this way, confusion **_and_** abuse are prevented and brings certainty through over-the-spot use.


**further cases**
- mostly for efficiency in establishing the connection.

- Unique product/board assignments 

- Together with the USB device classes, PID and VID can be used to create blacklists or whitelists. 
  Unique ID, which is a unique serial number per USB device, is the fourth feature. 
  In combination with the other three parameters, USB devices can be detected even more precisely


as far as publicly published projects are concerned, detailed project descriptions are then in the respective repo. Short descriptions as far as these do not emerge from the device name are added to the request. 

_requesting these PIDs on behalf_ 

**ESP32DE** 
https://github.com/ESP32DE


**ESPattoZero™** 
https://github.com/ESPattoZero


Used Chips are: **ESP32-S2** in this Request list

FYI: 
We use also ESP-32, and will use ESP32-C3, ESP32-S3 ... ESP32-Sx
so this list is not the last; as soon we have C3 / S3 in the hand
and we can test USB things and they can be used for it - there follows a next request.


0x8010 | ESP32DE Stickley-MIDI-PRO
Descr  : A Midi Pro Device for extended Function on the MIDI BUS  ( see Label "More Background")

0x8011 | ESP32DE Stickley-Arduino
Descr  : An Arduino Stickley Board

0x8012 | ESP32DE Stickley-UF2-Bootloader
Descr  : Stickley goes CircuitPython 

0x8013 | ESP32DE Stickley-CircuitPython
Descr  : Stickley goes CircuitPython

0x8014 | ESP32DE WiFi-CAN-Bridge-PRO
Descr  : A Wifi-CAN Bride Board for WIFI-CAN Communiacation

0x8015 | ESP32DE WiFi-OTG-Bridge-PRO
Descr  : A WIFI-OTG Bridge

0x8016 | ESP32DE WiFi-MCU-Bridge-PRO
Descr  : Connect the MCU Board over WIFI to HOST/Desktop/Mobil

0x8017 | ESP32DE LIVE-STYLER-PRO 
Descr  : DAW / Bridge for the PRO Musican

0x8018 | ESP32DE STICKLEY-PRO
Descr  : Stickley 2021 Journey Board with Mobil Function

0x8019 | ESP32DE MCU-Commander
Descr  : A MCU Commander with WIFI2USB Function

0x801A | ESP32DE -A-TESTDRIVE
Descr  : MESH Network in a USB MESH as an engineering TESTDRIVE (RAMDRIVE)

0x801B | ESP32DE -B-TESTHOST
Descr  : MESH Network in a USB MESH as an engineering TESTHOST (USB-CLOUD)

0x801C | ESP32DE -C-TESTDEVICE
Descr  : MESH Network in a USB MESH as an engineering TESTDEVICE (CLOUD-CLIENT) 

0x801D | ESP32DE -D-NEURONAL
Descr  : MESH Network in a USB MESH as an engineering neuronal network with AI & AIoT

0x801E | ESP32DE -E-REMOTE
Descr  : MESH Network in a USB MESH as an engineering rEMOTE uSER dIGITAL iNTERFACE

0x801F | ESP32DE -F-OSZ 
Descr  : MESH Network in a USB MESH as an engineering OSZ for measurement

0x8020 | ESP32DE PSRAMBANK-PRO
Descr  : The PSRAMBANK on an USB Stick / Board

0x8021 | ESP32DE WiFi-DONGLE
Descr  : A Wifi Dongle for the AI.MESH™

0x8022 | ESP32DE PeripheralBridge
Descr  : Wireless Peripheral 

0x8023 | ESP32DE SIMEPI™ DONGLE
Descr  : A Secure Dongle

0x8024 | ESP32DE AIoT-DONGLE
Descr  : An AIoT Dongle

0x8025 | ESP32DE IoT-DONGLE
Descr  : An IoT Dongle

0x8026 | ESP32DE WEBUSB-PRO
Descr  : A WebUSB Device with expanded function 

0x8027 | ESP32DE TINY-SHinY
Descr  : A Base Station Board for Communication between Desktop and several DECT-Low Energy Basisstation ( phones )   

0x8028 | ESP32DE devflowcharter PRO
Descr  : Flowcharter LIC-Stick with expanded Function

0x8029 | ESP32DE WEBSPI-PRO
Descr  : WEBSPI - a functional working SPI over a WEB

0x802A | ESPattoZero™ CircuitS
Descr  : The CircuitS Board with SNAPins for communication with Desktop Apps 

0x802B | ESPattoZero™ Engineering
Descr  : An Engineering Board for Circuits with DBG function and Desktop communication

0x802C | ESPattoZero™ Test fixture
Descr  : Preinstall and testings by a connected Test fixture Board

0x802D | ESPattozero™ Logic Analyzer
Descr  : A simple Logic Analyzer

0x802E | ESPattoZero™ Board Tester
Descr  : A universal Board Tester for the ESPattoZero Series 

0x802F | ESPattoZero™ Air quality tester
Descr  : Like the Device Name says it - an Air Quality Tester with USB Function

0x8030 | ESPattoZero™ X-ThermalPro
Descr  : Thermal CAM Pro 

0x8031 | ESPattoZero™ SECureCAM 
Descr  : SECure Camera

0x8032 | ESPattoZero™ StampIT
Descr  : A tinytiny ESP on a Stamp with USB Function

0x8033 | ESPattoZero™ Signalgenerator
Descr  : A Signalgenerator for the Hobbiest

0x8034 | ESPattoZero™ SnapSONzero
Descr  : An ultimate SnapOn USB Board for USB Communication with Zero Boards by X-Bridge

0x8035 | ESPattoZero™ SnapSONmini
Descr  : An ultimate SnapOn USB Board for USB Communication with Mini Boards by X-Bridge

0x8036 | ESPattoZero™ espKIT Home
Descr  : The espKIT for the Home

0x8037 | ESPattoZero™ espKIT Mobil
Descr  : The espKIT for the Mobil

0x8038 | ESPattoZero™ LoRa-X-Home
Descr  : LoRa-X-Home Board for the LoRa Net

0x8039 | ESPattoZero™ LoRa-X-Mobil
Descr  : LoRa-X-Mobil Board for the LoRa Net

0x803A | ESPattoZero™ ZERO-UF2-Bootloader
Descr  : ZERO-UF2-Bootloader

0x803B | ESPattoZero™ ZERO-CircuitPython
Descr  : ZERO-CircuitPython

0x803C | ESPattoZero™ ZERO-Arduino 
Descr  : ZERO-Arduino

0x803D | ESPattoZero™ SIMEPI™-Arduino 
Descr  : SIMEPI™-Arduino

0x803E | ESPattoZero™ RODI™-Arduino
Descr  : RODI™-Arduino

0x803F | ESPattoZero™ GRBL-DONGLE
Descr  : GRBL-DONGLE

0x8040 | ESPattoZero™ USB-MIDI32
Descr  : USB-MIDI32 an expanded MIDI Device for 32 Devices ( see Label "More Background")

0x8041 | ESPattoZero™ USB-MIDI64
Descr  : USB-MIDI32 an expanded MIDI Device for 64 Devices ( see Label "More Background")

0x8042 | ESPattoZero™ USB-MIDI128
Descr  : USB-MIDI32 an expanded MIDI Device for 128 Devices ( see Label "More Background")

0x8043 | ESPattoZero™ DMX-BASE-HOME
Descr  : A DMX Home ( Base ) for central serving DMX

0x8044 | ESPattpZero™ DMX-BASE-PRO
Descr  : A DMX PRO ( Base ) for expanded function for the PRO 

0x8045 | ESPattoZero™ B4A-Connect
Descr  : The ultimate B4A Dongle for Android Developing

0x8046 | ESPattoZero™ Android-Bridge
Descr  : Bridge for the remotly DBG and develop Android Apps with an Desktop thats run the ESPattoZero™ IDE for ESP

0x8047 | ESPattoZero™ CINEMA-SCOPE-IT
Descr  : CINEMA-SCOPE-IT ( ultra )

0x8048 | ESPattoZero™ MINI-SCOPE-IT
Descr  : MINI-SCOPE-IT ( base )

0x8049 | ESPattoZero™ X-LINK
Descr  : A Flasher and DBG 

0x804A | ESPattoZero™ BION-ELV 
Descr  : A BION Sensoric System - Stickley Journey 2021

0x804B | ESPattoZero™ EMU-x-
Descr  : An EMU System - Stickley Journey 2021

0x804C | ESPattoZero™ Switch-TH-ing
Descr  : A Switch Portal Board with Buttons and Knops / Knobs

0x804D | ESPattoZero™ VFM vehicle fleet manager
Descr  : VFM vehicle fleet manager

0x804E | ESPattoZero™ Health&Fitnees minder  
Descr  : Health&Fitnees minder 

0x804F | ESPattoZero™ DAW-PRO
Descr  : DAW Pro

0x8050 | ESPattoZero™ V-bridge
Descr  : Virtuell Bridge for your connected Things

0x8051 | ESPattoZero™ CPY-KIT
Descr  : A CircuitPython KIT 

0x8052 | ESPattoZero™ NUTTX-KIT
Descr  : A NUTTX-KIT

0x8053 | ESPattoZero™ DIY-KIT
Descr  : DIY-KIT with USB Connect.

0x8054 | ESPattoZero™ USB-CTM16
Descr  : USB-CTM16 expanded 16 Contact Device  ( see Label "More Background")

0x8055 | ESPattoZero™ USB-CTM32
Descr  : USB-CTM32 expanded 132 Contact Device  ( see Label "More Background")

0x8056 | ESPattoZero™ USB-CTM64
Descr  : USB-CTM64 expanded 64 Contact Device  ( see Label "More Background")

0x8057 | ESPattoZero™ USB-CTM128
Descr  : USB-CTM128 expanded 128 Contact Device  ( see Label "More Background")

0x8058 | ESPattoZero™ USB-MTC16
Descr  : USB-MTC16 expanded Function for 16 SIGS and for special Desktop App  ( see Label "More Background")

0x8059 | ESPattoZero™ USB-MTC32
Descr  : USB-MTC32 expanded Function for 32 SIGS and for special Desktop App  ( see Label "More Background")

0x805A | ESPattoZero™ USB-MTC64
Descr  : USB-MTC64 expanded Function for 64 SIGS and for special Desktop App  ( see Label "More Background")

0x805B | ESPattoZero™ USB-MTC128
Descr  : USB-MTC128 expanded Function for 128 SIGS and for special Desktop App  ( see Label "More Background")

0x805C | ESPattoZero™ CTM PRO
Descr  : Contact Device Base and expanded Function ( see Label "More Background")

0x805D | ESPattoZero™ MTC PRO
Descr  : SIGS Device Base and expanded Function ( see Label "More Background")

0x805E | ESPattoZero™ VCP2WiFi
Descr  : Virtual Communication Port to WiFi for connecting things wireless

0x805F | ESPattoZero™ EIA-485
Descr  : An EIA-485 Board / Stick 

0x8060 | ESPattoZero™ ESPattoZero-cero
Descr  : ESPattoZero™ Develop Board "cero"

0x8061 | ESPattoZero™ ESPattoZero-uno
Descr  : ESPattoZero™ Develop Board "uno"

0x8062 | ESPattoZero™ ESPattoZero-dos
Descr  : ESPattoZero™ Develop Board "dos"

0x8063 | ESPattoZero™ ESPattoZero-tres
Descr  : ESPattoZero™ Develop Board "tres"

0x8064 | ESPattoZero™ ESPattoZero-cuatro
Descr  : ESPattoZero™ Develop Board "cuatro"

0x8065 | ESPattoZero™ ESPattoZero-cinco
Descr  : ESPattoZero™ Develop Board "cinco"

0x8066 | ESPattoZero™ ESPattoZero-seis
Descr  : ESPattoZero™ Develop Board "seis"

0x8067 | ESPattoZero™ ESPattoZero-siete
Descr  : ESPattoZero™ Develop Board "siete"

0x8068 | ESPattoZero™ ESPattoZero-ocho
Descr  : ESPattoZero™ Develop Board "ocho"

0x8069 | ESPattoZero™ ESPattoZero-nueve
Descr  : ESPattoZero™ Develop Board "nueve"

0x806A | ESPattoZero™ PICOio-UF2
Descr  : Pico IO Board for IO ( UF2 Bootloader )

0x806B | ESPattoZero™ PICOio-CircuitPython
Descr  : Pico IO Board for IO (CircuitPython)

0x806C | ESPattoZero™ PICOio-Arduino
Descr  : Pico IO Board for the Arduino

0x806D | ESPattoZero™ PICOio-PRO-UF2
Descr  : Pico IO Pro Board for IO and expanded Function ( UF2 Bootloader )

0x806E | ESPattoZero™ PICOio-PRO-CircuitPython
Descr  : Pico IO Pro Board for IO and expanded Function ( CircuitPython )

0x806F | ESPattoZero™ PICOio-PRO-Arduino
Descr  : Pico IO Pro Board for the Arduino

0x8070 | ESPattoZero™ ATTO-UF2
Descr  : An Atto Board - UF2 Bootloader

0x8071 | ESPattoZero™ ATTO-CircuitPython
Descr  : An Atto Board - ( CircuitPython )

0x8072 | ESPattoZero™ ATTO-Arduino
Descr  : An Atto Board for the Arduino 

0x8073 | ESPattoZero™ ATTO-PRO-UF2
Descr  : An Atto Pro Board with expanded Functions ( UF2 Bootloader )

0x8074 | ESPattoZero™ ATTO-PRO-CircuitPython
Descr  : An Atto Pro Board with expandend Functions ( CircuitPython )

0x8075 | ESPattoZero™ ATTO-PRO-Arduino
Descr  : An Atto Pro Board for the Arduino

0x8076 | ESPattoZero™ MAMAMIA-UF2
Descr  : "MAMAMIA" - a fun board ( UF2 Bootloader )

0x8077 | ESPattoZero™ MAMAMIA-CircuitPython
Descr  : "MAMAMIA" - a fun board ( CircuitPython )

0x8078 | ESPattoZero™ MAMAMIA-Arduino
Descr  : "MAMAMIA" - a fun board for the Arduino

0x8079 | ESPattoZero™ LEONPI-MSI-PRO
Descr  : The LEONPI-MSI-Pro Board is an electronic measurement kit for experimentals with expanded function 

0x807A | ESPattoZero™ LEONPI-MSI-UF2
Descr  : The LEONPI-MSI-Pro Board is an electronic measurement kit for experimentals with expanded function (UF2 Bootloader)

0x807B | ESPattoZero™ LEONPI-MSI-CircuitPython
Descr  : The LEONPI-MSI-Pro Board is an electronic measurement kit for experimentals with expanded function (CircuitPython)

0x807C | ESPattoZero™ LEONPI-MSI-Arduino
Descr  : The LEONPI-MSI-Pro Board is an electronic measurement kit for experimentals with expanded function (Arduino)

0x807D | ESPattoZero™ GeoTracking Station
Descr  : A GeoTracking Station 

0x807E | ESPattoZero™ GeoTracking Base
Descr  : A GeoTracking Base

0x807F | ESPattoZero™ GeoTracking Mobil
Descr  : A GeoTracking for Mobil

0x8080 | ESPattoZero™ PROXY-NET
Descr  : PROXY-NET Stick / Board with Expansion

0x8081 | ESPattoZero™ PORT-NET
Descr  : PORT-NET Stick / Board with Expansion

0x8082 | ESPattoZero™ Studentenwerk Station
Descr  : STUDY CASE Project THE STATION

0x8083 | ESPattoZero™ Studentenwerk Client
Descr  : STUDY CASE Project THE CLIENT

0x8084 | ESPattoZero™ Studentenwerk Mobil
Descr  : STUDY CASE Project Mobil

0x8085 | ESPattoZero™ Studentenwerk YESAR
Descr  : STUDY CASE Project YESAR

0x8086 | ESPattoZero™ UNI VM-iAPX 86
Descr  : VM-iAPX 86 - A tiny VM

0x8087 | ESPattoZero™ UNI VM-x87 floating-point
Descr  : VM-x87 floating-point - A tiny VM

0x8088 | ESPattoZero™ UNI VM-8088
Descr  : VM-8088 - a tiny VM

0x8089 | ESPattoZero™ UNI VM-DMA
Descr  : VM-DMA - A tiny VM

0x808A | ESPattoZero™ Freifunk S2 Bridge
Descr  : Funkbruecke

0x808B | ESPattoZero™ Voltamere PI Station
Descr  : a Measuring equipment as Station

0x808C | ESPattoZero™ Voltamere PI Client
Descr  : a Measuring equipment as Client 

0x808D | ESPattoZero™ Voltamere PI Mobil
Descr  : a Measuring equipment as Mobil

0x808E | ESPattoZero™ Voltamere PI YESAR
Descr  : a Measuring equipment for ESPattoZero's YESAR system  

0x808F | ESPattoZero™ GPS NMEA Locater
Descr  : A GPS NMEA Locater ( FOX hunting by RADIO )

0x8090 | ESPattoZero™ GPS NMEA FOX
Descr  : A GPS NMEA FOX ( FOX hunting by RADIO )

0x8091 | ESPattoZero™ GPS NMEA HUNTER
Descr  : A GPS NMEA HUNTER ( FOX hunting by RADIO )

0x8092 | ESPattoZero™ GPS NMEA Base
Descr  : A GPS NMEA Base

0x8093 | ESPattoZero™ GPS NMEA Station
Descr  : A GPS NMEA Station Board

0x8094 | ESPattoZero™ GPS NMEA Mobil
Descr  : A GPS NMEA Mobil Dongle/Board

0x8095 | ESPattoZero™ GPS NMEA YESAR
Descr  : GPS NMEA YESAR Dongle/Board ( combi with a Dockingstion )

0x8096 | ESPattoZero™ NMEA Monitor
Descr  : A Monitoring System 

0x8097 | ESPattoZero™ USB Reminder
Descr  : Reminder by USB

0x8098 | ESPattoZero™ USB TrackingStar
Descr  : Trackingstar on USB 

0x8099 | ESPattoZero™ USB Router
Descr  : USB Routing Board / Stick ( Docker ) 

0x809A | ESPattoZero™ USB-INK 
Descr  : A USB Painter with expansion and IO functionality 

0x809B | ESPattoZero™ HOMESCHOOLING
Descr  : A SEC Key for the HOMESCHOOLING

0x809C | ESPattoZero™ UNI-VM-A7150-ROB-VEB
Descr  : SPECIAL TINY VM A7150 

0x809D | ESPattoZero™ UNI-VM-DCP1700-ROB-VEB
Descr  : SPECIAL TINY VM DCP1700 SYS

0x809E | ESPattoZero™ UNI-VM-DCP-GX-ROB-VEB
Descr  : SPECIAL TINY VM DCP-GX SYS

0x809F | ESPattoZero™ USB WIFI-HOTSPOT
Descr  : A Wifi Hotspot with Expansion for an eMbeddedHome

descr list is now completely
this request list for S2 ready for the merge

One request 
_0x---- | **ESP32DE SOFTUSB PRO**
DONGLE **soft-usb-device** with customized functions for communication between PC and connected MCU Device
use a custom SOFT USB class on my ESP32 which needs a non-standard driver on the host_

will be made separately and subsequently because it does not meet all the discussed requirements and is special.
it used the **ESP32, ESP32-PICO-D4, ESP32-PICO-V3, ESP32-PICO-V3-02** and is based on [SOFTUSB](https://github.com/ESP32DE/ESP32-SoftUSB) which we developed for the ESP32 - 
so perhabs you want not that we use a PID for a **SOFTUSB** for the **ESP32 Serie** so i will do this request after this request in a new request to not slow done this request by this "large" list 


![image](https://user-images.githubusercontent.com/16070445/107094488-5f6d7200-6807-11eb-9f60-3d13aa0855d7.png)


B/R
rudi
