### PR TITLE
Adding USB PID for Franzininho WIFI with Wrover module: UF2,CircuitPy…

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -177,3 +177,6 @@ PID    | Product name
 0x80A9 | Franzininho WIFI - Arduino
 0x80AA | Franzininho WIFI - CircuitPython
 0x80AB | Franzininho WIFI - UF2 Bootloader
+0x80AC | Franzininho WIFI Wrover - Arduino
+0x80AD | Franzininho WIFI Wrover - CircuitPython
+0x80AE | Franzininho WIFI Wrover - UF2 Bootloader


### PR DESCRIPTION
Hello,

I would like to use 3 PIDs for Franzininho WIFI board which uses the ESP32-S2 Wrover module.

Reason for custom PIDs are:

    CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID
    Arduino - In order to use a custom board on the Arduino IDE the board definition requires a unique PID to identify the board by its name.
    UF2 Bootloader - UF2 bootloader requires a unique PID for the USB device when it boots as a mass storage device.

I am requesting these PIDs on behalf of Franzininho, an open source project. You can find the project on: https://github.com/Franzininho/Franzininho-WIFI
More Detais about Franzininho: https://franzininho.com.br/ https://www.instagram.com/franzininho

Thank you