### PR TITLE
Add Artisense Reference Design

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -180,3 +180,5 @@ PID    | Product name
 0x80AC | Franzininho WIFI Wrover - Arduino
 0x80AD | Franzininho WIFI Wrover - CircuitPython
 0x80AE | Franzininho WIFI Wrover - UF2 Bootloader
+0x80AF | Artisense RD00 - CircuitPython
+0x80B0 | Artisense RD00 - UF2 Bootloader


### PR DESCRIPTION
I need some PIDs for adding CircuitPython and UF2 to our reference design (will create PRs once PIDs are assigned). The board will be used internally before shipping to make sure our sensors work as advertised, by our customers to get started with the sensor and for debugging.
The reference design is based on the ESP32-S2-WROVER module.

Company: Artisense GmbH
Website: https://artisense.ai