### PR TITLE
Add nanoESP32-S2 WROVER board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -183,3 +183,5 @@ PID    | Product name
 0x80AF | Artisense RD00 - CircuitPython
 0x80B0 | Artisense RD00 - UF2 Bootloader
 0x80B1 | Project Stida RoboCloud - CircuitPython
+0x80B2 | Muse Lab nanoESP32-S2 WROVER - CircuitPython
+0x80B3 | Muse Lab nanoESP32-S2 WROVER - UF2 Bootloader


### PR DESCRIPTION
I would like to use 2 PIDs for the WROVER version of the [Muse Lab nanoESP32-S2](https://github.com/wuxx/nanoESP32-S2) board which feature an ESP32-S2 WROVER.

These IDs will be used for :
- [CircuitPython](https://circuitpython.org/) port
- UF2 [Bootloader](https://github.com/adafruit/tinyuf2)

I have no link with Muse Lab or Adafruit, I am just writing a port of CP for this board and need 2 unique PID as requested by Adafruit.

Many thanks to offer this possibility !