### PR TITLE
Added Unexpected Maker FeatherS2 Neo - Arduino & CircuitPython

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -185,3 +185,5 @@ PID    | Product name
 0x80B1 | Project Stida RoboCloud - CircuitPython
 0x80B2 | Muse Lab nanoESP32-S2 WROVER - CircuitPython
 0x80B3 | Muse Lab nanoESP32-S2 WROVER - UF2 Bootloader
+0x80B4 | Unexpected Maker FeatherS2 Neo - Arduino
+0x80B5 | Unexpected Maker FeatherS2 Neo - CircuitPython


### PR DESCRIPTION
I'm requesting 2x PIDs for my new `FeatherS2 Neo` development board using the new ESP32-S2FN4R2. One for Arduino/IDF and one for CircuitPython.

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my FeatherS2 Neo would show up as UM FeatherS2 Neo instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, Unexpected Maker and though I don't have online info for my FeatherS2 Neo yet, here is what the boards looks like:
https://twitter.com/unexpectedmaker/status/1410055812584640525

Also, here are some links for my other ESP32 based boards:

TinyPICO (ESP32-PICO-D4) -https://tinypico.com
FeatherS2 (ESP32-S2) - https://feathers2.io
TinyS2 (EESP32-S2FN4R2) - https://tinys2.io
And more about Unexpected Maker - https://unexpectedmaker.com