### PR TITLE
PID request for Hypnocube LLC

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -190,3 +190,13 @@ PID    | Product name
 0x80B6 | Morpheans MorphESP-240 - UF2 Bootloader
 0x80B7 | Morpheans MorphESP-240 - UF2 Arduino
 0x80B8 | Morpheans MorphESP-240 - UF2 CircuitPython
+0x80B9 | Hypnocube - NewProduct1
+0x80BA | Hypnocube - NewProduct2
+0x80BB | Hypnocube - NewProduct3
+0x80BC | Hypnocube - NewProduct4
+0x80BD | Hypnocube - HypnoBall
+0x80BE | Hypnocube - HypnoLSD
+0x80BF | Hypnocube - HypnoCube8 
+0x80A0 | Hypnocube - HypnoCube4
+0x80A1 | Hypnocube - HypnoLights
+0x80A2 | Hypnocube - HypnoSquare8

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -197,6 +197,6 @@ PID    | Product name
 0x80BD | Hypnocube - HypnoBall
 0x80BE | Hypnocube - HypnoLSD
 0x80BF | Hypnocube - HypnoCube8 
-0x80A0 | Hypnocube - HypnoCube4
-0x80A1 | Hypnocube - HypnoLights
-0x80A2 | Hypnocube - HypnoSquare8
+0x80C0 | Hypnocube - HypnoCube4
+0x80C1 | Hypnocube - HypnoLights
+0x80C2 | Hypnocube - HypnoSquare8


### PR DESCRIPTION
We are upgrading several consumer products we make with ESP32 based ones. Our website is www.Hypnocube.com. We have been selling several of these products for over 15 years, appearing on a few TV shows, in media, and in stores. 

The six named products are 5 that have been released, a new one about to be finished, and we reserved a few more spots for future products (I hope that is ok!).

Short description: commercial art lighting products
Chip: plan on using ESP32-S3, perhaps update to future chips as relevant
Why: we want to be able to interact with our devices programatically from PCs and don't want to trigger on TinyUSB devices accidentally.
Company: Hypnocube LLC. I am a co-owner.
Website: www.hypnocube.com

Thanks for offering this service.