### PR TITLE
allocate PIDs for the HMI kit with UF2 & CircuitPython

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -196,3 +196,5 @@ PID    | Product name
 0x80BC | Hypnocube - HypnoCube4
 0x80BD | Hypnocube - HypnoLights
 0x80BE | Hypnocube - HypnoSquare8
+0x80BF | Espressif ESP32-S2-HMI-DevKit-1 - UF2 Bootloader
+0x80C0 | Espressif ESP32-S2-HMI-DevKit-1 - CircuitPython


### PR DESCRIPTION
Hi! We plan to add support for this board in Adafruit's tinyuf2 and circuitpython. It's our custom to allocate distinct VID/PID pairs for each device, and to distinguish between the bootloader, circuitpython, and any other environments such as arduino. Since this is Espressif hardware we thought it would make more sense to allocate Espressif PIDs for it than Adafruit, for the purposes of identification.

* https://github.com/adafruit/circuitpython/issues/5236

Thanks!