### PR TITLE
Add PIDs for Espressif ESP32-S3 DevKitC-1 board

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -7,4 +7,5 @@ stays sequential.
 PID    | Product name
 0x7000 | ESP32-S2-HMI-DevKit-1 - UF2 Bootloader
 0x7001 | ESP32-S2-HMI-DevKit-1 - CircuitPython
-
+0x7002 | ESP32-S3-DevKitC-1 - UF2 Bootloader
+0x7003 | ESP32-S3-DevKitC-1 - CircuitPython


### PR DESCRIPTION
Espressif ESP32-S3 DevKitC-1 
ESP32-S3
PIDs for TinyUF2 Bootloader and CircuitPython
