### PR TITLE
Add Soul Injector Firmware Programmer as 0x80CE

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -211,3 +211,4 @@ PID    | Product name
 0x80CB | BrainBoardz NeuronZ - Arduino
 0x80CC | BrainBoardz Neuron - UF2 Bootloader
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
+0x80CE | Soul Injector Firmware Programmer - Configurator


### PR DESCRIPTION
Hi there,

Here's a request for putting in my firmware programmer project. 

For the reason why a PID is needed (instead of using default PID) is because it may be harder to get the client configuration software to correctly enumerate and detect/identify the firmware programmer verses any other devices quickly.

Here's a reference for my project: https://twitter.com/huming2207/status/1439085302522339331
Here's the repo: https://github.com/huming2207/soul-injector

In this project, the microcontroller for now is ESP32-S3.

Thanks & Regards,
Jackson