### PR TITLE
Eigene PID

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -212,3 +212,4 @@ PID    | Product name
 0x80CC | BrainBoardz Neuron - UF2 Bootloader
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
 0x80CE | Soul Injector Firmware Programmer - Configurator
+0x80CF | Alc-Test - USB MSD

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -212,4 +212,4 @@ PID    | Product name
 0x80CC | BrainBoardz Neuron - UF2 Bootloader
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
 0x80CE | Soul Injector Firmware Programmer - Configurator
-0x80CF | Alc-Test - USB MSD
+0x80CF | CM-Manu Alc-Test - USB MSD


### PR DESCRIPTION
A brief description of what the device will do:  Testing Alcohol, store the mesurement values at a USB MSD
Which chip do you use: ESP32-S2
Why you need a custom PID: can't use the standard TinyUSB PIDs
Company name: CM Manufactory GmbH, Germany
