### PR TITLE
ESP32-S3-DevKitC-1: specify N8R2 on existing; add N8

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -7,5 +7,7 @@ stays sequential.
 PID    | Product name
 0x7000 | ESP32-S2-HMI-DevKit-1 - UF2 Bootloader
 0x7001 | ESP32-S2-HMI-DevKit-1 - CircuitPython
-0x7002 | ESP32-S3-DevKitC-1 - UF2 Bootloader
-0x7003 | ESP32-S3-DevKitC-1 - CircuitPython
+0x7002 | ESP32-S3-DevKitC-1-N8R2 - UF2 Bootloader
+0x7003 | ESP32-S3-DevKitC-1-N8R2 - CircuitPython
+0x7004 | ESP32-S3-DevKitC-1-N8 - UF2 Bootloader
+0x7005 | ESP32-S3-DevKitC-1-N8 - CircuitPython


### PR DESCRIPTION
Distinguish between N8R2 and N8 (no PSRAM) variants.