### PR TITLE
Added Unexpected Maker ESP32-S3 boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -213,3 +213,12 @@ PID    | Product name
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
 0x80CE | Soul Injector Firmware Programmer - Configurator
 0x80CF | CM-Manu Alc-Test - USB MSD
+0x80D0 | Unexpected Maker TinyS3 - Arduino
+0x80D1 | Unexpected Maker TinyS3 - CircuitPython
+0x80D2 | Unexpected Maker TinyS3 - UF2 Bootloader
+0x80D3 | Unexpected Maker ProS3 - Arduino
+0x80D4 | Unexpected Maker ProS3 - CircuitPython
+0x80D5 | Unexpected Maker ProS3 - UF2 Bootloader
+0x80D6 | Unexpected Maker FeatherS3 - Arduino
+0x80D7 | Unexpected Maker FeatherS3 - CircuitPython
+0x80D8 | Unexpected Maker FeatherS3 - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 9x PIDs for my 3 new ESP32-S3 development boards.
One each for CircuitPython, Arduino and the UF2 Bootloader

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, Unexpected Maker - here's a look at my new boards:
https://youtu.be/rcTrYBtaAMc

Thanks!