### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -222,3 +222,5 @@ PID    | Product name
 0x80D6 | Unexpected Maker FeatherS3 - Arduino
 0x80D7 | Unexpected Maker FeatherS3 - CircuitPython
 0x80D8 | Unexpected Maker FeatherS3 - UF2 Bootloader
+0x80D9 | FutureKeys HexKy S2 - CircuitPython
+0x80DA | FutureKeys HexKy S2 - UF2 Bootloader


### PR DESCRIPTION
added 2 new PID for HexKy esp32s2 boards one for UF2 Bootloader and one for CircuitPython