### PR TITLE
Add PIDs for Espressif ESP32-S3 DevKitM-1 board

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -11,3 +11,5 @@ PID    | Product name
 0x7003 | ESP32-S3-DevKitC-1 - CircuitPython
 0x7004 | ESP32-S3 Box - UF2 Bootloader
 0x7005 | ESP32-S3 Box - CircuitPython
+0x7006 | ESP32-S3-DevKitM-1 - UF2 Bootloader
+0x7007 | ESP32-S3-DevKitM-1 - CircuitPython


### PR DESCRIPTION
Espressif ESP32-S3 DevKitM-1
ESP32-S3
PIDs for TinyUF2 Bootloader and CircuitPython