### PR TITLE
Add PIDs for Hiibot IOTS2 dev board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -236,3 +236,5 @@ PID    | Product name
 0x80E4 | Banana Pi BPI:Bit v2 - UF2 Bootloader
 0x80E5 | Banana Pi BPI:Bit v2 - Arduino
 0x80E6 | Banana Pi BPI:Bit v2 - CircuitPython
+0x80E7 | Hiibot IoTS2 - UF2 Bootloader
+0x80E8 | Hiibot IoTS2 - CircuitPython


### PR DESCRIPTION
Hi, opening a request for PIDs for the Hiibot IOTS2.
- An ESP32-S2 based development board with smaller size (25.4*45.9mm), TFT-LCD, Battery Charging and Qwiic/STEMMA QT connector.
- ESP32-S2
- a custom PID required by tinyUF2
- a custom PID required by Circuitpython
- https://python4iots2.readthedocs.io/en/latest/index.html
- https://www.tindie.com/products/bradchan/hiibot-iots2/

Thanks