### PR TITLE
LILYGO TTGO T8 ESP32-S2 ESP32-S2-WROOM and LILYGO TTGO T8 ESP32-S2 ESP32-S2 (no Display)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -238,3 +238,6 @@ PID    | Product name
 0x80E6 | Banana Pi BPI:Bit v2 - CircuitPython
 0x80E7 | Hiibot IoTS2 - UF2 Bootloader
 0x80E8 | Hiibot IoTS2 - CircuitPython
+0x80E9 | LILYGO TTGO T8 ESP32-S2-WROOM - Arduino
+0x80EA | LILYGO TTGO T8 ESP32-S2-WROOM - CircuitPython
+0x80EB | LILYGO TTGO T8 ESP32-S2-WROOM - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -241,3 +241,6 @@ PID    | Product name
 0x80E9 | LILYGO TTGO T8 ESP32-S2-WROOM - Arduino
 0x80EA | LILYGO TTGO T8 ESP32-S2-WROOM - CircuitPython
 0x80EB | LILYGO TTGO T8 ESP32-S2-WROOM - UF2 Bootloader
+0x80EC | LILYGO TTGO T8 ESP32-S2 noDisplay - Arduino
+0x80ED | LILYGO TTGO T8 ESP32-S2 noDisplay - CircuitPython
+0x80EE | LILYGO TTGO T8 ESP32-S2 noDisplay - UF2 Bootloader


### PR DESCRIPTION
## LILYGO TTGO T8 ESP32-S2 ESP32-S2-WROOM

### A short description of what the device is going to do (e.g. cat tracker with USB trace download)

Development Board

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESPRESSIF-ESP32-S2-WROOM

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company

LILYGO

### If applicable/available, a website or other URL with information about your product or company

http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3

## LILYGO TTGO T8 ESP32-S2 ESP32-S2 (no Display)

This board is very similar to the one that is already present (`0x8006 | LILYGO TTGO T8 ESP32-S2 - Arduino` et al.) but there are some differences (not only the missing display).

### A short description of what the device is going to do (e.g. cat tracker with USB trace download)

Development Board

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESPRESSIF-ESP32-S2

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company

LILYGO

### If applicable/available, a website or other URL with information about your product or company

http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1300&FId=t3:50063:3


I'm not affiliated with LILYGO but I keep them in the loop.