### PR TITLE
add PIDs for GoGo Board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -244,3 +244,5 @@ PID    | Product name
 0x80EC | LILYGO TTGO T8 ESP32-S2 noDisplay - Arduino
 0x80ED | LILYGO TTGO T8 ESP32-S2 noDisplay - CircuitPython
 0x80EE | LILYGO TTGO T8 ESP32-S2 noDisplay - UF2 Bootloader
+0x80EF | GoGo Board - UF2 Bootloader
+0x80F0 | GoGo Board - Arduino


### PR DESCRIPTION
Hi, im opening this PR for GoGo Board PIDs

- A short description of what the device is going to do (e.g. cat tracker with USB trace download)
  > An educational devices

- What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
  > ESP32-S3

- Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
  > TinyUF2 and Arduino itself

- If you're requesting a PID on behalf of a company, please mention the name of the company
  > LILCMU, LogixEd

- If applicable/available, a website or other URL with information about your product or company
  > [GoGoBoard website](https://th.gogoboard.org)