### PR TITLE
Add PIDs for eSIGN

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -248,4 +248,5 @@ PID    | Product name
 0x80F0 | GoGo Board - Arduino
 0x80F1 | Tevofy Technology LTD - Muro Box MIDI N20
 0x80F2 | Tevofy Technology LTD - Muro Box MIDI N40
-0x80F3 | Werma Signaltechnik GmbH - eSIGN
+0x80F3 | WERMA Signaltechnik GmbH + Co. KG - eSIGN
+0x80F4 | WERMA Signaltechnik GmbH + Co. KG - eSIGN Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -248,3 +248,4 @@ PID    | Product name
 0x80F0 | GoGo Board - Arduino
 0x80F1 | Tevofy Technology LTD - Muro Box MIDI N20
 0x80F2 | Tevofy Technology LTD - Muro Box MIDI N40
+0x80F3 | Werma Signaltechnik GmbH - eSIGN


### PR DESCRIPTION
Hi, I would like to register these PIDs for our new Product

A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Industrial signaling device

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
The PIDs are required so that the PC Software can detect the product

If you're requesting a PID on behalf of a company, please mention the name of the company
WERMA Signaltechnik GmbH

If applicable/available, a website or other URL with information about your product or company
[https://www.werma.com/de/landing/esign/](https://www.werma.com/de/landing/esign/)
