### PR TITLE
Additional PID

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -252,3 +252,4 @@ PID    | Product name
 0x80F4 | WERMA Signaltechnik GmbH + Co. KG - eSIGN Bootloader
 0x80F5 | Lolin C3 Mini - CircuitPython
 0x80F6 | Unexpected Maker - Reflow Master Pro
+0x80F7 | Siemens - ECS


### PR DESCRIPTION
Hi,

I would like to register an additional PID for our Product.

A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Industrial signaling device

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
The PIDs are required so that the PC Software can detect and differentiate the product

If you're requesting a PID on behalf of a company, please mention the name of the company
Siemens