### PR TITLE
Request PID for Mixgo CE board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -256,3 +256,6 @@ PID    | Product name
 0x80F8 | Cytron Maker Feather AIoT S3 - Arduino
 0x80F9 | Cytron Maker Feather AIoT S3 - CircuitPython
 0x80FA | Cytron Maker Feather AIoT S3 - UF2 Bootloader
+0x80FB | MixGo CE - Arduino
+0x80FC | MixGo CE - CircuitPython
+0x80FD | MixGo CE - UF2 Bootloader


### PR DESCRIPTION
Hi, I would like to request to add the PID for Mixgo CE board

A short description of what the device is going to do (e.g. cat tracker with USB trace download)

A development board for ESP32-S2 form Mixly Team

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S2

If you're requesting a PID on behalf of a company, please mention the name of the company

Mixly Team

If applicable/available, a website or other URL with information about your product or company

[mixly.org](https://mixly.org/)