### PR TITLE
Add 0x80fe - PerpetCal Smart Calendar

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -259,3 +259,4 @@ PID    | Product name
 0x80FB | MixGo CE - Arduino
 0x80FC | MixGo CE - CircuitPython
 0x80FD | MixGo CE - UF2 Bootloader
+0x80FE | PerpetCal Smart Calendar - Configurator


### PR DESCRIPTION
Hi there,

Here's a request for putting in my smart calendar project's USB product ID: 0x80FE

It's basically a low-power HMI device that talks to an API server. The API server takes an iCalendar feed (or something else later) and pushes it to the client device. The USB will be used for reading/writing configurations to the device (e.g. WiFi SSID, iCalendar feed URL etc.). It's not a standard CDC serial, and it will be much easier for the client app to detect the device when it is being connected.

Here's a reference for my project (server-side): https://github.com/huming2207/perpetcal-api

The firmware hasn't been started yet, but some research has been done, see here:

- https://twitter.com/huming2207/status/1503140566527197189
- https://twitter.com/huming2207/status/1520318409124110336

In this project, the microcontroller for now is ESP32-S3, using modules with 8MB PSRAM like ESP32-S3-WROOM-2-N32R8V.

Thanks & Regards,
Jackson