### PR TITLE
Allocate PIDs for MiniMain ESP32-S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -260,3 +260,6 @@ PID    | Product name
 0x80FC | MixGo CE - CircuitPython
 0x80FD | MixGo CE - UF2 Bootloader
 0x80FE | PerpetCal Smart Calendar - Configurator
+0x80FF | MiniMain ESP32-S2 - Arduino
+0x8100 | MiniMain ESP32-S2 - CircuitPython
+0x8101 | MiniMain ESP32-S2 - UF2 Bootloader


### PR DESCRIPTION
Hello. I would like to register these PIDs for my new board, MiniMain ESP32-S2.

> A short description of what the device is going to do:

A controller board for haunted attraction props. Control lighting, pneumatics, and sound.

> What chip are you using for the device the PID is allocated for

ESP32-S2

> If you're requesting a PID on behalf of a company, please mention the name of the company

At this moment it is just me. But may be a company named Department of Alchemy soon.

> If applicable/available, a website or other URL with information about your product or company

Here is the GitHub location for the board: https://github.com/DepartmentOfAlchemy/minimain-esp32-s2