### PR TITLE
Allocate IoT-PostBox v1 board PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -263,3 +263,6 @@ PID    | Product name
 0x80FF | MiniMain ESP32-S2 - Arduino
 0x8100 | MiniMain ESP32-S2 - CircuitPython
 0x8101 | MiniMain ESP32-S2 - UF2 Bootloader
+0x8102 | IoT-PostBox v1 - Arduino
+0x8103 | IoT-PostBox v1 - CircuitPython
+0x8104 | IoT-PostBox v1 - UF2 Bootloader


### PR DESCRIPTION
Hi, I would like to request the relative PIDs for IoT-PostBox v1 board

> A short description of what the device is going to do (e.g. cat tracker with USB trace download)

It is a PostBox mail tracker that detects when you get a mail and notifies it using Wifi or Lora network.

> What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

It is based on an ESP32-S2 MCU

> Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

I need them to program it with CircuitPython, Arduino IDE and the Host application.

> If you're requesting a PID on behalf of a company, please mention the name of the company

No company at this time yet

> If applicable/available, a website or other URL with information about your product or company

The Kicad designs and some firmware can be found under this repo:  https://github.com/paclema/iot-postbox/tree/master/pcb_desings

Thank you!