### PR TITLE
Allocate PIDs for MuseLab ESPLink

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -266,3 +266,7 @@ PID    | Product name
 0x8102 | IoT-PostBox v1 - Arduino
 0x8103 | IoT-PostBox v1 - CircuitPython
 0x8104 | IoT-PostBox v1 - UF2 Bootloader
+0x8105 | MuseLab ESP32-S2 ESPLink - esp-usb-bridge
+0x8106 | MuseLab ESP32-S2 ESPLink - Arduino
+0x8107 | MuseLab ESP32-S2 ESPLink - CircuitPython
+0x8108 | MuseLab ESP32-S2 ESPLink - UF2 Bootloader


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
a debugger based on Espressif's esp-usb-bridge (https://github.com/espressif/esp-usb-bridge), which can debug ESP series chip.

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
for device identification，and someone may use it with arduino/circuitpython

If you're requesting a PID on behalf of a company, please mention the name of the company
MuseLab, we are a technical team from china

If applicable/available, a website or other URL with information about your product or company
here is the github repo https://github.com/wuxx/ESPLink