### PR TITLE
Add Waveshare ESP32-S2-Pico-LCD

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -272,3 +272,5 @@ PID    | Product name
 0x8108 | MuseLab ESP32-S2 ESPLink - UF2 Bootloader
 0x8109 | Waveshare ESP32-S2-Pico - UF2 Bootloader
 0x810a | Waveshare ESP32-S2-Pico - CircuitPython
+0x810B | Waveshare ESP32-S2-Pico-LCD - UF2 Bootloader
+0x810C | Waveshare ESP32-S2-Pico-LCD - CircuitPython


### PR DESCRIPTION
Adding second variant of the Waveshare ESP32-S2-Pico with a LCD.
It needs own PIDs because the name is similar but the hardware is different.