### PR TITLE
Add M5STACK S3 series boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -286,4 +286,12 @@ PID    | Product name
 0x8116 | Lolin S3 - Arduino
 0x8117 | Lolin S3 - CircuitPython
 0x8118 | Lolin S3 - UF2 Bootloader
-
+0x8119 | M5STACK CoreS3 - Arduino
+0x811A | M5STACK CoreS3 - CircuitPython
+0x811B | M5STACK CoreS3 - UF2 Bootloader
+0x811C | M5STACK StickS3 - Arduino
+0x811D | M5STACK StickS3 - CircuitPython
+0x811E | M5STACK StickS3 - UF2 Bootloader
+0x811F | M5STACK AtomS3 - Arduino
+0x8120 | M5STACK AtomS3 - CircuitPython
+0x8121 | M5STACK AtomS3 - UF2 Bootloader


### PR DESCRIPTION
Add M5STACK S3 series boards.

Docs is not ready yet, once we're ready, you can see it [here](https://docs.m5stack.com/en/products?id=core) :)