### PR TITLE
Add PIDs for BPI-PicoW-S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -304,3 +304,6 @@ PID    | Product name
 0x8128 | RobotClass Graphite S2 - UF2 Bootloader
 0x8129 | RIKA FireNet 2.0 USB-WiFi Stick - Bootloader
 0x812A | RIKA FireNet 2.0 USB-WiFi Stick - Production Firmware
+0x812B | Banana Pi BPI-PicoW-S3 - Arduino
+0x812C | Banana Pi BPI-PicoW-S3 - CircuitPython
+0x812D | Banana Pi BPI-PicoW-S3 - UF2 Bootloader


### PR DESCRIPTION
Hello, I would like to request 3 PIDs for Banana Pi BPI-PicoW-S3 dev boards, with ESP32-S3 chip.

A PID of UF2 Bootloader, Arduino, and CircuitPython.
———————————————————
Custom PIDs are required due to:

UF2 / UF2-Bootloader - requires a unique PID for the USB device when it boots as a mass storage device as TinyUF2 doesn't allow sharing the same PIDs here.

Arduino - a unique PID allows the board to be listed by the proper board name instead of "generic ESP32 dev board"

CircuitPython - Adafruit requires every board that runs CircuitPython to have a unique PID.
———————————————————
I'm requesting these PIDs on behalf of my company, Banana Pi.

Official website: https://banana-pi.org/

Many thanks for your time.