### PR TITLE
Add PIDs for CharaChorder Lite-S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -307,3 +307,5 @@ PID    | Product name
 0x812B | Banana Pi BPI-PicoW-S3 - Arduino
 0x812C | Banana Pi BPI-PicoW-S3 - CircuitPython
 0x812D | Banana Pi BPI-PicoW-S3 - UF2 Bootloader
+0x812E | CharaChorder Lite-S2
+0x812F | CharaChorder Lite-S2 UF2 Bootloader


### PR DESCRIPTION
Could you add PIDs for the CharaChorder Lite S2?
The device uses the ESP32-S2.
We need a custom driver for the UF2 bootloader and application.
The company is CharaChorder LLC
The product information is on our website here: https://www.charachorder.com/products/charachorder-lite