### PR TITLE
Add PIDs for Refract AXIS

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -309,3 +309,4 @@ PID    | Product name
 0x812D | Banana Pi BPI-PicoW-S3 - UF2 Bootloader
 0x812E | CharaChorder Lite-S2
 0x812F | CharaChorder Lite-S2 UF2 Bootloader
+0x8130 | Refract AXIS


### PR DESCRIPTION
Hi,

Thanks for this service, its a great help!

1. A short description of what the device is going to do (e.g. cat tracker with USB trace download)
    AXIS is a body tracking device, much like a motion capture suit.

2. What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
    We are using the ESP32-S3.

3. Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
    We need a custom PID as we are writing custom drivers/runtimes and we need to be able to detect that our device is 
    connected.

4. If you're requesting a PID on behalf of a company, please mention the name of the company
    I am requesting on behalf of Refract Technologies.

5. If applicable/available, a website or other URL with information about your product or company
    Our company website is https://refract.gg/, you can find more information about our product there.

Please let me know if you require any additional information!