### PR TITLE
Add PIDs for SoftRF devices

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -310,3 +310,7 @@ PID    | Product name
 0x812E | CharaChorder Lite-S2
 0x812F | CharaChorder Lite-S2 UF2 Bootloader
 0x8130 | Refract AXIS
+0x8131 | SoftRF WebTop USB S2
+0x8132 | SoftRF Standalone Edition S3
+0x8133 | SoftRF Prime Edition Mk3
+0x8134 | SoftRF Prime Edition Mk3 - UF2 Bootloader


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp; Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. SoftRF is a proximity awareness system for general aviation
2. We are using both ESP32-S2 and ESP32-S3
3. We need a custom PIDs to work with our custom [application software](https://github.com/lyusupov/SoftRF/wiki/SoftRF-Configuration-Tool)
4. [Website](https://github.com/lyusupov/SoftRF)

Please, let me know if you require any additional information!
