### PR TITLE
Requesting PID 0x8131 for Sensory Bridge

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -310,4 +310,4 @@ PID    | Product name
 0x812E | CharaChorder Lite-S2
 0x812F | CharaChorder Lite-S2 UF2 Bootloader
 0x8130 | Refract AXIS
-0x8131 | Sensory Bridge - Arduino
+0x8135 | Sensory Bridge - Arduino

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -310,3 +310,4 @@ PID    | Product name
 0x812E | CharaChorder Lite-S2
 0x812F | CharaChorder Lite-S2 UF2 Bootloader
 0x8130 | Refract AXIS
+0x8131 | Sensory Bridge - Arduino


### PR DESCRIPTION
Thank you in advance, love your work!

---------

### A short description of what the device is going to do (e.g. cat tracker with USB trace download)

Sensory Bridge is built from the ground up as an open, powerful bridge between sight and sound. With a show that's reactive to notation, vibrato and more, it produces very unique and pleasant-to-look-at light shows which synchronize to your music without any visible latency.

---------

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

I am using the ESP32-S2.

---------

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

I need a custom PID to allow for [VID:PID] device filtering in WebSerial applications!

---------

### If you're requesting a PID on behalf of a company, please mention the name of the company

I am requesting on behalf of Lixie Labs.

---------

### If applicable/available, a website or other URL with information about your product or company

The product landing site for Sensory Bridge is:
https://sensorybridge.rocks/

The Software (MIT License) is:
https://github.com/connornishijima/SensoryBridge

The Hardware (CERN-OHL-W-2.0) is:
https://github.com/connornishijima/SensoryBridge/tree/main/extras/OSHW

Please let me know if you have any questions!