### PR TITLE
Add PIds for Matatalab devices

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -315,3 +315,7 @@ PID    | Product name
 0x8133 | SoftRF Prime Edition Mk3
 0x8134 | SoftRF Prime Edition Mk3 - UF2 Bootloader
 0x8135 | Sensory Bridge - Arduino
+0x8136 | Matatalab Universal Robot S3
+0x8137 | Matatalab VinciBot S3
+0x8138 | Matatalab TaleBot S3
+0x8139 | Matatalab MatataBot S3


### PR DESCRIPTION
Dear Maintainers,
thank you so much for this great service!
Please,  check this pull request.


1. Our Device have USB CDC and MSC function, Mainly used for file storage and communication.
2. We are using  ESP32-S3 On our already mass-produced products and several new products planned in the near future.
3. We need custom PIDs to work with our application software (https://coding.matatalab.com/), Mainly used for equipment identification and screening.
4. I request PIDs for my company(https://matatalab.com/)

Please, let me know if you require any additional information!