### PR TITLE
Add PIDs for Flash64

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -319,3 +319,7 @@ PID    | Product name
 0x8137 | Matatalab VinciBot S3
 0x8138 | Matatalab TaleBot S3
 0x8139 | Matatalab MatataBot S3
+0x813A | Flash64 Ultra
+0x813B | Flash64 UF2 Bootloader
+0x813C | Flash64 Lite
+0x813D | Flash64 Deluxe


### PR DESCRIPTION
Greetings Dear Colleagues,

I wish to apply for PIDs   0x813A, 0x813B, 0x813C and 0x813D.

1. Flash64 products are Flash IC Programmers for eMMC, UFS, NAND and SPI.

2. We are currently in the final stages of hardware development using an ESP32-S3-WROOM-1-N16R8 Module.

3. We need custom PIDs because we are using a Vendor Specific Interface Class for USB communication with our proprietary software.

4. Our company name is ShenZhen ZhengMa Electronic Ltd.

5. The website for the Flash64 product is still under development. It will be deployed sometime in 2Q2023. However, the url has already been reserved at www.flash64.com


Best Regards