### PR TITLE
Add PIDs for Deneyap Development Boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -326,3 +326,15 @@ PID    | Product name
 0x813E | LILYGO T-Display-S3 - Arduino
 0x813F | LILYGO T-Display-S3 - CircuitPython
 0x8140 | LILYGO T-Display-S3 - UF2 Bootloader
+0x8141 | Deneyap Mini - Arduino
+0x8142 | Deneyap Mini - CircuitPython
+0x8143 | Deneyap Mini - UF2 Bootloader
+0x8144 | Deneyap Mini v2 - Arduino
+0x8145 | Deneyap Mini v2 - CircuitPython
+0x8146 | Deneyap Mini v2 - UF2 Bootloader
+0x8147 | Deneyap Kart 1A v2 - Arduino
+0x8148 | Deneyap Kart 1A v2 - CircuitPython
+0x8149 | Deneyap Kart 1A v2 - UF2 Bootloader
+0x814A | Deneyap Kart G - Arduino
+0x814B | Deneyap Kart G - CircuitPython
+0x814C | Deneyap Kart G - UF2 Bootloader


### PR DESCRIPTION
Hello, I would like to request 12 PIDs for Deneyap Development Boards
- Deneyap Mini (ESP32-S2)
- Deneyap Mini v2 (ESP32-S2)
- Deneyap Kart 1A v2 (ESP32-S3)
- Deneyap Kart G (ESP32-C3)

I'm requesting these PIDs on behalf of my company, Deneyap Kart

Official website: https://deneyapkart.org/en/