### PR TITLE
s

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -338,3 +338,11 @@ PID    | Product name
 0x814A | Deneyap Kart G - Arduino
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
+0x814D | xProject AI Interface - Arduino
+0x814E | xProject AI Interface - CircuitPython
+0x814F | xProject AI Interface - UF2 Bootloader
+0x8150 | xProject Adapter Interface Pro
+0x8151 | xProject Adapter Interface Lite
+
+
+

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -343,6 +343,3 @@ PID    | Product name
 0x814F | xProject AI Interface - UF2 Bootloader
 0x8150 | xProject Adapter Interface Pro
 0x8151 | xProject Adapter Interface Lite
-
-
-


### PR DESCRIPTION
Device Purpose:
Adapter interface for communicating
with fuel injected motorcycles engine control unit / manager (ecu/ecm)

Chips used:
ESP-WROOM-32
ESP32-DevKitC

Reason for pid req:
Device requires for custom driver to properly achieve custom baudrate and timings required by different ecu manufacturers and also ensure proper control of the voltage leveling due to motorcycles operating on 12v


