### PR TITLE
Updated PID Allocation Request

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -338,3 +338,7 @@ PID    | Product name
 0x814A | Deneyap Kart G - Arduino
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
+0x814D | xProject AI Interface - UF2 Bootloader
+0x814E | xProject Adapter Interface Pro
+0x814F | xProject Adapter Interface Lite
+0x8150 | xProject Adapter Interface

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -339,6 +339,6 @@ PID    | Product name
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
 0x814D | xProject AI Interface - UF2 Bootloader
-0x814E | xProject Adapter Interface Pro
+0x814E | xProject Adapter Interface PRO
 0x814F | xProject Adapter Interface Lite
 0x8150 | xProject Adapter Interface


### PR DESCRIPTION
Device Purpose:
Adapter interface for communicating
with fuel injected motorcycles engine control unit / manager (ecu/ecm)

Chips used:
Release:
ESP32-S2
ESP32-S3-WROOM-1-N16R8 Module.

Prototyping:
ESP-WROOM-32
ESP32-DevKitC

Reason for pid req:
Device requires for custom driver to properly achieve custom baudrate and timings required by different ecu manufacturers and also ensure proper control of the voltage leveling due to motorcycles operating on 12v which is managed by custom software