### PR TITLE
Update allocated PID

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -338,3 +338,5 @@ PID    | Product name
 0x814A | Deneyap Kart G - Arduino
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
+0x814D | Valetron Systems VALTRACK-V4-VTS-ESP32-C3
+0x814E | Valetron Systems VALTRACK-V4-MFW-ESP32-C3


### PR DESCRIPTION
Device Purpose:
VALTRACK-V4-VTS-ESP32-C3 is a 4G-LTE Vehicle tracking device  VALTRACK-V4-MFW-ESP32-C3 is a 4G-LTE Asset tracking device 

Chips used:

ESP32-C3
EPS32-C3FH4

Reason for PID req:
Device requires custom drivers for parameter configuration of cellular connection parameters & server details.