### PR TITLE
Added Crabik Slot ESP32-S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -338,3 +338,4 @@ PID    | Product name
 0x814A | Deneyap Kart G - Arduino
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
+0x814D | Crabik Slot ESP32-S3 - Arduino or CircuitPython


### PR DESCRIPTION
Hi!

I am requesting 1 PID for my new development board on ESP32-S3.

The reason for the custom PIDs are:

For user applications that use USB.

Arduino or CircuitPython is specified in this request, but it can be any (there can be an application on Rust). For programming, the built-in USB CDC/JTAG is used, which already has a VID and a PID, and in the Arduino IDE the board will be displayed under a random name in any case.  Therefore, I do not see the point in a separate PID for each individual application.

I am requesting this PID on behalf of a private person (at the moment), Roman Samusevich (gh kekcheburec).

Product Information (to be updated) [crabikboards.com]( https://crabikboards.com/) or [tech info](https://tech-docs.crabikboards.com/boards/slot-esp32-s3/README.html)

Thanks!