### PR TITLE
Added PID codes for Chroma.tech Canopy

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -339,3 +339,5 @@ PID    | Product name
 0x814B | Deneyap Kart G - CircuitPython
 0x814C | Deneyap Kart G - UF2 Bootloader
 0x814D | Crabik Slot ESP32-S3 - Arduino or CircuitPython
+0x814E | Chroma.tech Canopy
+0x814F | Chroma.tech Canopy - MicroPython


### PR DESCRIPTION
PID codes for Chroma.tech Canopy controllers. 

Chroma.tech makes LED controllers for large scale art installations and architecture lighting. The controllers are based on ESP32-S3.

Custom PID will allow our online config software to easily filter for Chroma.tech devices with our company name in the Web Serial dialog.

https://chroma.tech