### PR TITLE
Add Lilygo T-embed S3 board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -341,3 +341,6 @@ PID    | Product name
 0x814D | Crabik Slot ESP32-S3 - Arduino or CircuitPython
 0x814E | Chroma.tech Canopy
 0x814F | Chroma.tech Canopy - MicroPython
+0x8150 | LILYGO T-Embed-S3 - Arduino
+0x8151 | LILYGO T-Embed-S3 - CircuitPython
+0x8152 | LILYGO T-Embed-S3 - UF2 Bootloader


### PR DESCRIPTION
## LILYGO TTGO T8 ESP32-S2 ESP32-S2-WROOM

### A short description of what the device is going to do (e.g. cat tracker with USB trace download)

Development Board with a screen and a rotary encoder with Leds

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESPRESSIF-ESP32-S3-WROOM

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company

LILYGO

### If applicable/available, a website or other URL with information about your product or company

https://www.lilygo.cc/products/t-embed
https://github.com/Xinyuan-LilyGO/T-Embed