### PR TITLE
Add LilyGo TTGO T-QT

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -344,3 +344,6 @@ PID    | Product name
 0x8150 | LILYGO T-Embed-S3 - Arduino
 0x8151 | LILYGO T-Embed-S3 - CircuitPython
 0x8152 | LILYGO T-Embed-S3 - UF2 Bootloader
+0x8153 | LILYGO T-QT - Arduino
+0x8154 | LILYGO T-QT - CircuitPython
+0x8155 | LILYGO T-QT - UF2 Bootloader


### PR DESCRIPTION
## LILYGO TTGO T-QT (and T-QT Pro variants with differing PSRAM/flash size)
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Development Board with a 128x128 screen and two buttons in a small form factor

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESPRESSIF ESP32-S3FN4R2

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company
LILYGO

### If applicable/available, a website or other URL with information about your product or company
https://www.lilygo.cc/products/t-qt-pro https://github.com/Xinyuan-LilyGO/T-QT https://www.lilygo.cc/products/t-qt-v1-1 (now replaced with Pro but still around, only difference was lipo recharger on pro and varying flash/ram)

