### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -347,3 +347,4 @@ PID    | Product name
 0x8153 | LILYGO T-QT - Arduino
 0x8154 | LILYGO T-QT - CircuitPython
 0x8155 | LILYGO T-QT - UF2 Bootloader
+0x8156 | CableMate


### PR DESCRIPTION
**Description:**
Strain gauge measurement USB device.

**Device:**
ESP32-S3-WROOM-1-N16 (custom board)

**Reason:**
So we can use custom driver for setting baudrate and ADC gains etc. depending on the product you plug in. (We will add more products in future)

**Company name:**
CC Athletics

**Link:**
https://ccathletics.dk