### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -348,3 +348,5 @@ PID    | Product name
 0x8154 | LILYGO T-QT - CircuitPython
 0x8155 | LILYGO T-QT - UF2 Bootloader
 0x8156 | CableMate
+0x8157 | MD-PLUG Type C
+0x8158 | MD-PLUG Type A


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
- Secure data transmit USB plug 

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
- ESP32-S3

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
- We would like a unique PID for selling our products for commercial purposes.

If you're requesting a PID on behalf of a company, please mention the name of the company
- GMDSOFT Inc.

If applicable/available, a website or other URL with information about your product or company
- www.gmdsoft.com