### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -350,3 +350,5 @@ PID    | Product name
 0x8156 | CableMate
 0x8157 | MD-PLUG Type C
 0x8158 | MD-PLUG Type A
+0x8159 | Shrooly SH01 - UF2 Bootloader
+0x815A | Shrooly SH01 - Production Firmware 


### PR DESCRIPTION
Shrooly ltd produces indoor mushroom cultivator.

In the products we use ESP32-S3 microcontroller.

We need unique PID for the product because our configurator software uses VID/PID pair to recognize the products for configuration and for automated firmware upgrade.

To find out more about our products you can visit https://shrooly.com