### PR TITLE
Add M5Stack AtomS3 Lite board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -356,3 +356,5 @@ PID    | Product name
 0x815C | Smart Bee Designs Bee Data Logger - Arduino
 0x815D | Smart Bee Designs Bee Data Logger - CircuitPython
 0x815E | Smart Bee Designs Bee Data Logger - UF2 Bootloader
+0x815F | M5STACK AtomS3 Lite - CircuitPython
+0x8160 | M5STACK AtomS3 Lite - UF2 Bootloader


### PR DESCRIPTION
# A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Development Board with one button, an RGB led, a grove port and some GPIOs

# What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
EspressIf ESP32-S3FN8

# Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and CircuitPython require unique PIDs for any new boards added

# If you're requesting a PID on behalf of a company, please mention the name of the company
M5Stack

# If applicable/available, a website or other URL with information about your product or company

[https://docs.m5stack.com/en/core/AtomS3 20Lite](https://docs.m5stack.com/en/core/AtomS3%20Lite)

