### PR TITLE
Add LOLIN S3 Pro board.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -358,3 +358,6 @@ PID    | Product name
 0x815E | Smart Bee Designs Bee Data Logger - UF2 Bootloader
 0x815F | M5STACK AtomS3 Lite - CircuitPython
 0x8160 | M5STACK AtomS3 Lite - UF2 Bootloader
+0x8161 | LOLIN S3 Pro - Arduino
+0x8162 | LOLIN S3 Pro - CircuitPython
+0x8163 | LOLIN S3 Pro - UF2 Bootloader


### PR DESCRIPTION
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Development Board with one button, an RGB led, a I2C port, a microSD slot  based ESP32-S3-WROOM-1.

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
 ESP32-S3-WROOM-1 (ESP32-S3)

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company
WEMOS

### If applicable/available, a website or other URL with information about your product or company
[https://www.wemos.cc/en/latest/s3/s3_pro.html](https://www.wemos.cc/en/latest/s3/s3_pro.html)