### PR TITLE
Add YD-ESP32-S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -361,3 +361,6 @@ PID    | Product name
 0x8161 | LOLIN S3 Pro - Arduino
 0x8162 | LOLIN S3 Pro - CircuitPython
 0x8163 | LOLIN S3 Pro - UF2 Bootloader
+0x8164 | YD-ESP32-S3 - Arduino
+0x8165 | YD-ESP32-S3 - UF2 Bootloader
+0x8166 | YD-ESP32-S3 - CircuitPython


### PR DESCRIPTION
I got this board off of ebay.

Some stuff of it is detailed here:
https://github.com/vcc-gnd/YD-ESP32-S3

I have no affiliation with the board maker.
I just got the board and want to make an official CircuitPython port.
I have already finished the technical side of the port.