### PR TITLE
Add LOLIN S3 Mini board.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -364,3 +364,6 @@ PID    | Product name
 0x8164 | YD-ESP32-S3 - Arduino
 0x8165 | YD-ESP32-S3 - UF2 Bootloader
 0x8166 | YD-ESP32-S3 - CircuitPython
+0x8167 | LOLIN S3 Mini - Arduino
+0x8168 | LOLIN S3 Mini - CircuitPython
+0x8169 | LOLIN S3 Mini - UF2 Bootloader


### PR DESCRIPTION
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Development WiFi & Bluetooth 5 (LE) boards based ESP32-S3FH4R2.

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3FH4R2

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and CircuitPython require unique PIDs for any new boards added

### If you're requesting a PID on behalf of a company, please mention the name of the company
WEMOS

### If applicable/available, a website or other URL with information about your product or company
https://www.wemos.cc/en/latest/s3/s3_mini.html