### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -373,3 +373,4 @@ PID    | Product name
 0x816D | M5STACK TimerCamS3 - Arduino
 0x816E | M5STACK TimerCamS3 - CircuitPython
 0x816F | M5STACK TimerCamS3 - UF2 Bootloader
+0x8170 | CaniotBox - Production Firmware


### PR DESCRIPTION
CaniotBox is a multiplatform testing and development tool for CAN bus systems,based on ESP32-S3, we need this PID that our tool is able to list only  their virtual serial ports.