### PR TITLE
Update to allocated PID for 4 devices for Talk All Sport

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -378,7 +378,7 @@ PID    | Product name
 0x8172 | 01Space ESP32-S3-0.42OLED - CircuitPython
 0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython 
 0x8174 | 01Space ESP32-S3-0.42OLED - UF2 Bootloader
-0x8175| Talk All Sport - Base Station
-0x8176| Talk All Sport - Hand Controller
-0x8177| Talk All Sport - Speech Unit
-0x8178| Talk All Sport - Arm Remote
+0x8175 | Talk All Sport - Base Station
+0x8176 | Talk All Sport - Hand Controller
+0x8177 | Talk All Sport - Speech Unit
+0x8178 | Talk All Sport - Arm Remote

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -374,3 +374,7 @@ PID    | Product name
 0x816E | M5STACK TimerCamS3 - CircuitPython
 0x816F | M5STACK TimerCamS3 - UF2 Bootloader
 0x8170 | CaniotBox - Production Firmware
+0x8171 | Talk All Sport - Base Station
+0x8172 | Talk All Sport - Hand Controller
+0x8173 | Talk All Sport - Speech Unit
+0x8174 | Talk All Sport - Arm Remote

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -374,7 +374,11 @@ PID    | Product name
 0x816E | M5STACK TimerCamS3 - CircuitPython
 0x816F | M5STACK TimerCamS3 - UF2 Bootloader
 0x8170 | CaniotBox - Production Firmware
-0x8171 | Talk All Sport - Base Station
-0x8172 | Talk All Sport - Hand Controller
-0x8173 | Talk All Sport - Speech Unit
-0x8174 | Talk All Sport - Arm Remote
+0x8171 | 01Space ESP32-S3-0.42OLED - Arduino
+0x8172 | 01Space ESP32-S3-0.42OLED - CircuitPython
+0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython 
+0x8174 | 01Space ESP32-S3-0.42OLED - UF2 Bootloader
+0x8175| Talk All Sport - Base Station
+0x8176| Talk All Sport - Hand Controller
+0x8177| Talk All Sport - Speech Unit
+0x8178| Talk All Sport - Arm Remote


### PR DESCRIPTION
These devices make up the four parts of a sports scoring system. 
They are using ESP32-S3-WROOM-1 modules.
The devices will be a commercial product so require to have a professional driver installed, thus prefer to not use. TinyUSB as the PID. The Company is Talk All Sport, see talkallsport.com.

Thanks in advance