### PR TITLE
Add 01Space ESP32-S3-0.42OLED boards 

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -374,3 +374,7 @@ PID    | Product name
 0x816E | M5STACK TimerCamS3 - CircuitPython
 0x816F | M5STACK TimerCamS3 - UF2 Bootloader
 0x8170 | CaniotBox - Production Firmware
+0x8171 | 01Space ESP32-S3-0.42OLED - Arduino
+0x8172 | 01Space ESP32-S3-0.42OLED - CircuitPython
+0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython 
+0x8174 | 01Space ESP32-S3-0.42OLED - UF2 Bootloader


### PR DESCRIPTION
Hi Spritetm！

I have revised the file, thank you!

A short description of what the device is going to do (e.g. cat tracker with USB trace download)
ESP32-S3-0.42OLED Development boards based ESP32-S3FH4R2.

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3FH4R2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and ARduino, MicroPython,CircuitPython require unique PIDs for any new boards added

If you're requesting a PID on behalf of a company, please mention the name of the company

01Space

If applicable/available, a website or other URL with information about your product or company
https://www.aliexpress.com/item/1005004942536689.html?spm=a2g0o.productlist.main.1.6d274562eGaNXP&algo_pvid=80819ad9-b2f2-40c9-b801-3197718e654e&algo_exp_id=80819ad9-b2f2-40c9-b801-3197718e654e-0&pdp_npi=3%40dis%21USD%2111.99%2111.99%21%21%21%21%21%40211bd4cd16834504786718606d07fa%2112000031100333495%21sea%21US%21252527236&curPageLogUid=FcpisDFlRud4&gatewayAdapt=4itemAdapt

https://github.com/01Space/ESP32-S3-0.42OLED