### PR TITLE
Add Banana Pi BPI-Centi-S3 board.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -391,3 +391,6 @@ PID    | Product name
 08817F | Unexpected Maker Bling - Arduino
 0x8180 | Unexpected Maker Bling - CircuitPython
 0x8181 | Unexpected Maker Bling - UF2 Bootloader
+0x8182 | Banana Pi BPI-Centi-S3 - Arduino
+0x8183 | Banana Pi BPI-Centi-S3 - CircuitPython
+0x8184 | Banana Pi BPI-Centi-S3 - UF2 Bootloader


### PR DESCRIPTION
Hello, I would like to request 3 PIDs for Banana Pi BPI-Centi-S3 dev boards, with ESP32-S3 chip.

A PID of UF2 Bootloader, Arduino, and CircuitPython.
———————————————————
Custom PIDs are required due to:

UF2 / UF2-Bootloader - requires a unique PID for the USB device when it boots as a mass storage device as TinyUF2 doesn't allow sharing the same PIDs here.

Arduino - a unique PID allows the board to be listed by the proper board name instead of "generic ESP32 dev board"

CircuitPython - Adafruit requires every board that runs CircuitPython to have a unique PID.
———————————————————
I'm requesting these PIDs on behalf of my company, Banana Pi.

[Official product  website](https://banana-pi.org/en/banana-pi-steam/147.html)

Many thanks for your time.