### PR TITLE
Add new Unexpected Maker ESP32-S3 boards.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -382,3 +382,12 @@ PID    | Product name
 0x8176 | Talk All Sport - Hand Controller
 0x8177 | Talk All Sport - Speech Unit
 0x8178 | Talk All Sport - Arm Remote
+088179 | Unexpected Maker NanoS3 - Arduino
+0x817A | Unexpected Maker NanoS3 - CircuitPython
+0x817B | Unexpected Maker NanoS3 - UF2 Bootloader
+08817C | Unexpected Maker BlizzardS3 - Arduino
+0x817D | Unexpected Maker BlizzardS3 - CircuitPython
+0x817E | Unexpected Maker BlizzardS3 - UF2 Bootloader
+08817F | Unexpected Maker Bling - Arduino
+0x8180 | Unexpected Maker Bling - CircuitPython
+0x8181 | Unexpected Maker Bling - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 9x PIDs for my 3 new ESP32-S3 based boards.

One each for CircuitPython, Arduino and the UF2 Bootloader

The Boards

NanoS3 - A tiny ESP32-S3 based module that's compatible with my TinyPICO Nano board.
BlizzardS3 - A super small ESP32-S3 + ICE40 FPGA Hybrid board
Bling! - A tiny ESP32S3 board with 320x 1010 RGB Addressable LEDs on one side and everything including the kitchen sink.
Two boards feature the ESP32-S3FN8 + additional PSRAM and the Bling board uses an ESP32-S3-MINI1-8

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, Unexpected Maker

Thanks :)