### PR TITLE
Add PIDs for CharaChorder Engine S2 and CharaChorder X S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -307,3 +307,5 @@ PID    | Product name
 0x812B | Banana Pi BPI-PicoW-S3 - Arduino
 0x812C | Banana Pi BPI-PicoW-S3 - CircuitPython
 0x812D | Banana Pi BPI-PicoW-S3 - UF2 Bootloader
+0x812E | CharaChorder Lite-S2
+0x812F | CharaChorder Lite-S2 UF2 Bootloader


### PR DESCRIPTION
Could you add PIDs for the CharaChorder Engine S2, CharaChorder X S2, and CharaChorder X Host S2?
The Engine and the X are two different products. The Engine uses one ESP32-S2. The X uses two ESP32-S2 chips.
We need two PIDs for each device. One for the application and another for the UF2 bootloader.
The company is CharaChorder LLC
The product information is on our website here:
https://www.charachorder.com/products/charachorder-engine-pre-order
https://www.charachorder.com/products/charachorder-x