### PR TITLE
Add PIDs for LilyGO T-TWR Plus

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -404,3 +404,6 @@ PID    | Product name
 0x818C | CharaChorder X S2 - UF2 Bootloader
 0x818D | CharaChorder X S2 Host
 0x818E | CharaChorder X S2 Host - UF2 Bootloader
+0x818F | LilyGO T-TWR Plus S3 - Arduino
+0x8190 | LilyGO T-TWR Plus S3 - CircuitPython/Micropython
+0x8191 | LilyGO T-TWR Plus S3 - UF2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. Development board with SA868 radio, PMU, GNSS, 128x64 OLED display and 21700 battery holder
2. ESPRESSIF ESP32-S3-WROOM-1-N16R8
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. LilyGO
5. https://www.lilygo.cc/products/t-twr-plus

Please, let me know if you require any additional information!
