### PR TITLE
add uPesy C3/S3 boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -407,3 +407,15 @@ PID    | Product name
 0x818F | LilyGO T-TWR Plus S3 - Arduino
 0x8190 | LilyGO T-TWR Plus S3 - CircuitPython/Micropython
 0x8191 | LilyGO T-TWR Plus S3 - UF2 Bootloader
+0x8192 | uPesy ESP32S3 Devkit - Arduino
+0x8193 | uPesy ESP32S3 Devkit - CircuitPython
+0x8194 | uPesy ESP32S3 Devkit - UF2 Bootloader
+0x8195 | uPesy ESP32C3 Basic - Arduino
+0x8196 | uPesy ESP32C3 Basic - CircuitPython
+0x8197 | uPesy ESP32C3 Basic - UF2 Bootloader
+0x8198 | uPesy ESP32C3 Pro - Arduino
+0x8199 | uPesy ESP32C3 Pro - CircuitPython
+0x819A | uPesy ESP32C3 Pro - UF2 Bootloader
+0x819B | uPesy ESP32C3 Mini - Arduino
+0x819C | uPesy ESP32C3 Mini - CircuitPython
+0x819D | uPesy ESP32C3 Mini - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 12x PIDs for my 4 new ESP32-S3/C3 based boards.

One each for CircuitPython, Arduino and the UF2 Bootloader

The Boards

uPesy ESP32S3 Devkit - A devkit board based on a ESP32-S3 N16R8 module devkit board.
uPesy ESP32C3 Basic - A devkit board based on a ESP32-C3 module devkit board with ultra low power consomption in deep-sleep (<15µA).
uPesy ESP32C3 Pro - An improved version of  uPesy ESP32C3 Basic with built-in battery charging and a second LDO.
uPesy ESP32C3 Mini - A tiny devkit board based on the ESP32-C3-MINI module with ULP consomption in deep sleep.
![image](https://github.com/espressif/usb-pids/assets/61392244/b8a0ac76-fe95-472f-ba10-7546bd8b34d1)


Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, uPesy Electronics https://www.upesy.com/

Thanks :)
Alexis