### PR TITLE
Add Lunii FLAM product (S3)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -407,3 +407,4 @@ PID    | Product name
 0x818F | LilyGO T-TWR Plus S3 - Arduino
 0x8190 | LilyGO T-TWR Plus S3 - CircuitPython/Micropython
 0x8191 | LilyGO T-TWR Plus S3 - UF2 Bootloader
+0x8192 | Lunii FLAM


### PR DESCRIPTION
Hello, 

I would like to request a PID for FLAM product made by the Lunii company.
It integrates a ESP32-S3 (USB) and an ESP32-MINI-1-N4 

———————————————————
Custom PIDs are required due to:

Usage as mass storage with PC software which has to be able to recognize the product based on PID.
———————————————————
I'm requesting these PIDs on behalf of my client, the Lunii company.

[Official product website](https://lunii.com/fr-fr/flam-baladeur-audio-interactif/)

Many thanks for your time.