### PR TITLE
Add PIDs for ESP32-S3 SoftRF Midi device

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -421,3 +421,5 @@ PID    | Product name
 0x819D | uPesy ESP32C3 Mini - UF2 Bootloader
 0x819E | Lunii FLAM
 0x819F | LAEPI safe.EAR - Arduino
+0x81A0 | SoftRF Midi Edition S3
+0x81A1 | SoftRF Midi Edition S3 - UF2 Bootloader


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp; Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. SoftRF is a proximity awareness system for general aviation
2. We are using ESP32-S3 for the Midi Edition
3. We need a custom PIDs to work with our custom [application software](https://github.com/lyusupov/SoftRF/wiki/SoftRF-Configuration-Tool)
4. [Website](https://github.com/lyusupov/SoftRF)

Please, let me know if you require any additional information!
