### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -425,3 +425,4 @@ PID    | Product name
 0x81A1 | SoftRF Midi Edition S3 - UF2 Bootloader
 0x81A2 | Waveshare ESP32-S3-Pico - UF2 Bootloader
 0x81A3 | Waveshare ESP32-S3-Pico - CircuitPython
+0x81A4 | ProjectSource CORE_D4 LITE - ProjectSource


### PR DESCRIPTION
![CORE_D4-LITE](https://github.com/espressif/usb-pids/assets/47790980/789111cf-d2ed-48b9-8d51-257c96321761)

This device is going to be used for educational and industrial purposes. Robotics, PLCs, etc.

**Chip**: ESP32-PICO-D4

**Why**: In a custom IDE I can figure out what device is plugged in.

**Company**: ProjectSource (https://projectsource.nl/)