### PR TITLE
Add PIDs for ESP32-S2 VTR Effects Guitar Pedal

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -425,3 +425,5 @@ PID    | Product name
 0x81A1 | SoftRF Midi Edition S3 - UF2 Bootloader
 0x81A2 | Waveshare ESP32-S3-Pico - UF2 Bootloader
 0x81A3 | Waveshare ESP32-S3-Pico - CircuitPython
+0x81A4 | Kailani Reverb - VTR Effects
+

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -426,4 +426,8 @@ PID    | Product name
 0x81A2 | Waveshare ESP32-S3-Pico - UF2 Bootloader
 0x81A3 | Waveshare ESP32-S3-Pico - CircuitPython
 0x81A4 | Kailani Reverb - VTR Effects
+0x81A5 | Narciso Delay - VTR Effects
+0x81A6 | Helios Overdrive - VTR Effects
+0x81A7 | Venator Distortion - VTR Effects
+0x81A8 | Loki Modulation - VTR Effects
 


### PR DESCRIPTION
Guitar Reverb Pedal, using the ESP32-S2. I need the PID on behalf of VTR Effects as we are developing our software to control the pedal via USB communication.

https://vtreffects.com.br/produto/kailani-reverb-gold-series/
https://vtreffects.com.br/produto/narciso-delay/
https://vtreffects.com.br/produto/helios-overdrive-gold-series/