### PR TITLE
Allocate PIDs for MagiClick S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -430,4 +430,8 @@ PID    | Product name
 0x81A6 | Helios Overdrive - VTR Effects
 0x81A7 | Venator Distortion - VTR Effects
 0x81A8 | Loki Modulation - VTR Effects
+0x81A9 | MagiClick S3 - Arduino
+0x81AA | MagiClick S3 - CircuitPython
+0x81AB | MagiClick S3 - MicroPython 
+0x81AC | MagiClick S3 - UF2 Bootloader
 


### PR DESCRIPTION
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)

a keyboard based on Espressif's esp32-s3.It can also be used as an ESP32 development kit

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S3

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

for device identification，and someone may use it with arduino/circuitpython/micropython/tingyuf2

### If you're requesting a PID on behalf of a company, please mention the name of the company

I'm a maker and love to do DIY work

### If applicable/available, a website or other URL with information about your product or company

here is the github repo  [https://github.com/MakerM0/MagiClick-esp32s3](https://github.com/MakerM0/MagiClick-esp32s3)