### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -434,4 +434,7 @@ PID    | Product name
 0x81AA | MagiClick S3 - CircuitPython
 0x81AB | MagiClick S3 - MicroPython 
 0x81AC | MagiClick S3 - UF2 Bootloader
+0x81AD | Creekside S3 - Buzzer Receiver
+0x81AE | Creekside S3 - Buzzer
+0x81AF | Creekside S3 - Buzzer Tool
 


### PR DESCRIPTION

- A short description of what the device is going to do (e.g. cat tracker with USB trace download)
For game shows, it is a receiver that connects to multiple buzzers using a custom made mesh network running on top of ESP-NOW

- What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3

- Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

We run a pc library that identifies the devices and connects to them as serial com ports. This is to make it so we don't try to connect to any ESP from the library.

- If you're requesting a PID on behalf of a company, please mention the name of the company
Requesting from us, Creekside AB

- If applicable/available, a website or other URL with information about your product or company
www.creekside.se
We are a small company building custom embedded systems.