### PR TITLE
Add new Unexpected Maker TinyWATCH-S3 project.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -437,4 +437,6 @@ PID    | Product name
 0x81AD | Creekside S3 - Buzzer Receiver
 0x81AE | Creekside S3 - Buzzer
 0x81AF | Creekside S3 - Buzzer Tool
-
+0881B0 | Unexpected Maker TinyWATCH-S3 - Arduino
+0x81B1 | Unexpected Maker TinyWATCH-S3 - CircuitPython
+0x81B2 | Unexpected Maker TinyWATCH-S3 - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 3x PIDs for my TinyWATCH-S3 project.

One each for CircuitPython, Arduino and the UF2 Bootloader

TinyWATCH-S3 will be an open-source ESP32-S3 based "everything + the kitchen sink" smartwatch project.

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf on my Company, Unexpected Maker

Thanks :)