### PR TITLE
Update allocated-pids-espressif-devboards.txt

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -21,3 +21,4 @@ PID    | Product name
 0x700D | ESP32-S3 Box Lite - CircuitPython
 0x700E | ESP32-S3-EYE - UF2 Bootloader
 0x700F | ESP32-S3-EYE - CircuitPython
+0x7010 | ESP32-WROOM-32 - Motion platform simulator


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
- The device we're planning to use will function as the host MCU for a Motion platform simulator

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
- The chip selected for this project is the ESP32-WROOM-32.

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
- The ESP32 microcontroller offers unique features and functionalities that are required for the device/application;  
  therefore, TinyUSB is not of interest.

If you're requesting a PID on behalf of a company, please mention the name of the company
- The name of the company is Fasetech.

If applicable/available, a website or other URL with information about your product or company
- Link to the company website: https://fasetech.com/

