### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -440,3 +440,4 @@ PID    | Product name
 0881B0 | Unexpected Maker TinyWATCH-S3 - Arduino
 0x81B1 | Unexpected Maker TinyWATCH-S3 - CircuitPython
 0x81B2 | Unexpected Maker TinyWATCH-S3 - UF2 Bootloader
+0x81B3 | Prokyber Esp32-C6-Bug - CircuitPython


### PR DESCRIPTION
1)Esp32-C6 development board
2)Esp32-C6FH4
3)CircuitPython requires unique USB id and they explicitly state that they want the unique one
4)Prokyber s.r.o.
5)https://www.crowdsupply.com/prokyber-s-r-o/esp32-c6-bug