### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -440,3 +440,5 @@ PID    | Product name
 0881B0 | Unexpected Maker TinyWATCH-S3 - Arduino
 0x81B1 | Unexpected Maker TinyWATCH-S3 - CircuitPython
 0x81B2 | Unexpected Maker TinyWATCH-S3 - UF2 Bootloader
+0xB1B3 | Waveshare ESP32-S3-Zero - UF2 Bootloader
+0xB1B4 | Waveshare ESP32-S3-Zero - UF2 CircuitPython


### PR DESCRIPTION
I have ported CircuitPython to the Waveshare ESP32-S3-Zero board (pull request with the wrong PID pending here: https://github.com/adafruit/circuitpython/compare/main...Axeia:circuitpython-ESP32-S3-Zero:main
This PID request is solely to get it approved for CircuitPython.

I have contacted Waveshare as well and got the go ahead to request a PID on their behalf. Waveshare's site can be found over here:
https://www.waveshare.com/

The specific product this is for:
https://www.waveshare.com/esp32-s3-zero.htm