### PR TITLE
Add senseBox MCU-S2 ESP32-S2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -445,3 +445,7 @@ PID    | Product name
 0x81B5 | LILYGO T-Deck - Arduino
 0x81B6 | LILYGO T-Deck - CircuitPython/Micropython
 0x81B7 | LILYGO T-Deck - UF2 Bootloader
+0x81B8 | senseBox MCU-S2 ESP32-S2 - Arduino
+0x81B9 | senseBox MCU-S2 ESP32-S2 - CircuitPython
+0x81BA | senseBox MCU-S2 ESP32-S2 - UF2 Bootloader
+


### PR DESCRIPTION
I'm asking for 3 PIDs for our new senseBox MCU-S2 with ESP32-S2.
One each for Arduino, Circuit Python and the UF2 Bootloader

The senseBox MCU-S2 is an open source ESP32-S2 based board which will be mainly used in education and citizen science projects together with a series of sensors and other electronic components. A graphical (blockly) based programming interface (https://blockly.sesenbox.de) supports the young learners in developing their own project ideas. Sensor data gets published on the [openSenseMap](https://opensensemap.org/) and can used by everybody for free.

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader
Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, the board can be easily recognized as the correct one.

I am requesting these PIDs on behalf of the senseBox-Project which is a joint project by the university of muenster and reedu. More informations about the project can found on our [website](https://sensebox.de/en/)

Thanks you very much