### PR TITLE
Allocate PIDs for LILYGO T-Deck

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -442,3 +442,6 @@ PID    | Product name
 0x81B2 | Unexpected Maker TinyWATCH-S3 - UF2 Bootloader
 0x81B3 | Waveshare ESP32-S3-Zero - UF2 Bootloader
 0x81B4 | Waveshare ESP32-S3-Zero - UF2 CircuitPython
+0x81B5 | LILYGO T-Deck - Arduino
+0x81B6 | LILYGO T-Deck - CircuitPython/Micropython
+0x81B7 | LILYGO T-Deck - UF2 Bootloader


### PR DESCRIPTION
> A short description of what the device is going to do (e.g. cat tracker with USB trace download)

_T-Deck is a pocket-sized gadget with a 2.8-inch, 320 x 240 pixel IPS LCD display, a mini keyboard, and an ESP32 dual-core processor. While it's not exactly a smartphone, you can use your programming knowledge to turn it into a standalone messaging device, or coding software._
https://www.lilygo.cc/products/t-deck

> What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S3

> Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

Adding supported builds for MicroPython and CircuitPython.

> If you're requesting a PID on behalf of a company, please mention the name of the company

Requesting on behalf of LILYGO

> If applicable/available, a website or other URL with information about your product or company

https://www.lilygo.cc/products/t-deck
https://github.com/Xinyuan-LilyGO/T-Deck
