### PR TITLE
Add PIDs for ESP32-S3 PowerFeather

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -448,4 +448,6 @@ PID    | Product name
 0x81B8 | senseBox MCU-S2 ESP32-S2 - Arduino
 0x81B9 | senseBox MCU-S2 ESP32-S2 - CircuitPython
 0x81BA | senseBox MCU-S2 ESP32-S2 - UF2 Bootloader
+0x81BB | ESP32-S3 PowerFeather ESP32-S3 - Arduino
+0x81BC | ESP32-S3 PowerFeather ESP32-S3 - CircuitPython
 


### PR DESCRIPTION
> A short description of what the device is going to do (e.g. cat tracker with USB trace download)

ESP32-S3 PowerFeather is a development board focused on battery-powered/off-grid applications.

> What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S3

> Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

The PIDs will be used for Arduino (WIP) and CircuitPython (planned) support. For the former, it's so that the board can be properly associated with a friendly name in the IDE after firmware upload; for the latter, unique PID is required by Adafruit.

> If applicable/available, a website or other URL with information about your product or company

www.powerfeather.dev