### PR TITLE
Add UF2 bootloader PID for ESP32-S3 PowerFeather

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -450,4 +450,5 @@ PID    | Product name
 0x81BA | senseBox MCU-S2 ESP32-S2 - UF2 Bootloader
 0x81BB | ESP32-S3 PowerFeather ESP32-S3 - Arduino
 0x81BC | ESP32-S3 PowerFeather ESP32-S3 - CircuitPython
+0x81BD | ESP32-S3 PowerFeather ESP32-S3 - UF2 Bootloader
 


### PR DESCRIPTION
Additional PID request to https://github.com/espressif/usb-pids/pull/123.

Hi @Spritetm, forgot the PID for UF2 bootloader. Other boards which has CircuitPython support applied for a PID for it, so I will also here (sorry, not too familiar yet with adding support for CircuitPython). 