### PR TITLE
Add Makerfabs MaTouch products

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -451,4 +451,7 @@ PID    | Product name
 0x81BB | ESP32-S3 PowerFeather ESP32-S3 - Arduino
 0x81BC | ESP32-S3 PowerFeather ESP32-S3 - CircuitPython
 0x81BD | ESP32-S3 PowerFeather ESP32-S3 - UF2 Bootloader
+0x81BE | Makerfabs MaTouch ESP32-S3 - Arduino
+0x81BF | Makerfabs MaTouch ESP32-S3 - CircuitPython
+0x81C0 | Makerfabs MaTouch ESP32-S3 - UF2 Bootloader
 


### PR DESCRIPTION
A series with a capacitive touch screen that can be used as a custom keyboard and other functions.
ESP32-S3

We have customers who have developed branches of the PyDOS shell and need to provide PID for the product when merging.
This requires an independent PID based on our company.

Company: Makerfabs
Home Page: https://www.makerfabs.com/

vincent@makerfabs.com