### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -454,4 +454,8 @@ PID    | Product name
 0x81BE | Makerfabs MaTouch ESP32-S3 - Arduino
 0x81BF | Makerfabs MaTouch ESP32-S3 - CircuitPython
 0x81C0 | Makerfabs MaTouch ESP32-S3 - UF2 Bootloader
+0x81C1 | ADRIA-electronic - UF2 Bootloader
+0x81C2 | ADRIA-electronic - AECE5 - Card encoder
+0x81C3 | ADRIA-electronic - AEOFF - Offline flasher
+0x81C4 | ADRIA-electronic - AEMPG - Multi-protocol gateway
 


### PR DESCRIPTION
> A short description of what the device is going to do 

- UF2 Bootloader
- RFID/NFC card reader
- Offline flasher tool
- Multiprotocol (CAN/RS485...) USB gateway

> What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S3

> Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

We are using custom HID protocols for our devices.

> If you're requesting a PID on behalf of a company, please mention the name of the company

ADRIA-electronic d.o.o.

> If applicable/available, a website or other URL with information about your product or company

[https://www.ae.hr](https://www.ae.hr)