### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -458,4 +458,13 @@ PID    | Product name
 0x81C2 | ADRIA-electronic - AECE5 - Card encoder
 0x81C3 | ADRIA-electronic - AEOFF - Offline flasher
 0x81C4 | ADRIA-electronic - AEMPG - Multi-protocol gateway
-
+0x81C5 | Ultradrom - USB HID Plus
+0x81C6 | Ultradrom - USB MIDI Controller Plus
+0x81C7 | Ultradrom - USB Mass Storage Plus
+0x81C8 | Ultradrom - USB Joystick Plus
+0x81C9 | Ultradrom - USB Gamepad Plus
+0x81CA | Ultradrom - USB HID
+0x81CB | Ultradrom - USB MIDI Controller
+0x81CC | Ultradrom - USB Mass Storage
+0x81CD | Ultradrom - USB Joystick
+0x81CE | Ultradrom - USB Gamepad


### PR DESCRIPTION
1) "A short description of what the device is going to do (e.g. cat tracker with USB trace download)":
Family of USB-devices with accessibility features: Keyboard, Mouse, MIDI-Controllers, Game-controllers. Bluetooth as option.

2) "What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)":
ESP32-S3 (USB/Bluetooth)
ESP32-S2 (USB)

3) "Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)":
For device identification, events filtering and prevent conflicts with other devices.

4) "If you're requesting a PID on behalf of a company, please mention the name of the company": 
Ultradrom

5) "If applicable/available, a website or other URL with information about your product or company":
ultradrom.com