### PR TITLE
Updated allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -468,3 +468,6 @@ PID    | Product name
 0x81CC | Ultradrom - USB Mass Storage
 0x81CD | Ultradrom - USB Joystick
 0x81CE | Ultradrom - USB Gamepad
+0x81CF | Columbia DSL Sensor Board - Arduino
+0x81D0 | Columbia DSL Sensor Board - CircuitPython
+0x81D1 | Columbia DSL Sensor Board - UF2 Bootloader


### PR DESCRIPTION
Pull request to add PIDs for the Columbia DSL Sensor board. This board is designed to be used as part of Columbia University's Digial Storytelling Lab's courses in physical computing. 

It uses an ESP32-S3-WROOM-1 and has various sensors for the students to easily interact with. 

We need unique PIDs to add the board to Arduino's board list and CircuitPython (Adafruit requires unique PIDs for CircuitPython and UF2 bootloader).

The board is being designed by my company, Double Take Labs.

www.doubletake.design