### PR TITLE
SterlingKey

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -471,3 +471,4 @@ PID    | Product name
 0x81CF | Columbia DSL Sensor Board - Arduino
 0x81D0 | Columbia DSL Sensor Board - CircuitPython
 0x81D1 | Columbia DSL Sensor Board - UF2 Bootloader
+0x81D2 | Sterling Hawk - SterlingKey


### PR DESCRIPTION
I would like to register an PID for my product.

A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Reads connected keyboard input and retransmits it to a wireless protocol, to make a wired keyboard wireless

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
I want to create a firmware updater program (and possibly remapper) and I want it to automatically detect my device

If you're requesting a PID on behalf of a company, please mention the name of the company
My own startup

If applicable/available, a website or other URL with information about your product or company
https://sterling-key.com/