### PR TITLE
Add Meocap device

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -472,3 +472,5 @@ PID    | Product name
 0x81D0 | Columbia DSL Sensor Board - CircuitPython
 0x81D1 | Columbia DSL Sensor Board - UF2 Bootloader
 0x81D2 | Sterling Hawk - SterlingKey
+0x81D3 | Meocap Receiver
+0x81D4 | Meocap Receiver - UF2 Bootloader


### PR DESCRIPTION
Hello, I would like to register a PID on behalf of my company (@KesongTech).

1. A short description of what the device is going to do (e.g. cat tracker with USB trace download)

This device acts as the receiver for our full-body motion capture system. 

2. What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S2

3. Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

Our driver and update tool relies on PID to recognize the receiver. And we are going to open source this product for public usage.

4. If you're requesting a PID on behalf of a company, please mention the name of the company

KesongTech (@KesongTech)

5. If applicable/available, a website or other URL with information about your product or company

Sorry that we do not have a homepage yet. But there is a demonstration video (Chinese) for our product on BiliBili https://www.bilibili.com/video/BV1Fz4y137tW/
