### PR TITLE
Add Chameleon Key

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -474,3 +474,5 @@ PID    | Product name
 0x81D2 | Sterling Hawk - SterlingKey
 0x81D3 | Meocap Receiver
 0x81D4 | Meocap Receiver - UF2 Bootloader
+0x81D5 | HSBL-ko-gyo HSBL-S100 Chameleon Key
+0x81D6 | HSBL-ko-gyo HSBL-S100 Chameleon Key - UF2 Bootloader


### PR DESCRIPTION
Hello. I would like to assign a PID to the firmware for the ESP32-S3 that I have created and am planning to sell.

・A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Macro device with customizable screen from browser

・What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3

・Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
We would like to automatically detect the device, and when commercializing it, we would like to have it assigned a PID.

・If you're requesting a PID on behalf of a company, please mention the name of the company
I'm still an individual. There is a possibility that I will start my own corporation in the future, but it is undecided.

・If applicable/available, a website or other URL with information about your product or company
What is currently published https://sites.google.com/view/hsbl-industrial-hp/home/2023%E4%BD%9C%E5%93%81chameleon-key?authuser=0

HP scheduled to be released (under construction) https://sites.google.com/view/hsbl-s100/%E3%83%9B%E3%83%BC%E3%83%A0

Video https://www.youtube.com/watch?v=NukuTUWTc60

Reduced functionality version OSS that gives you an idea of the configuration tool
https://hsbl-ko-gyo.github.io/HSBL-S101/