### PR TITLE
Add PIDs for ESP32-S2 VTR Effects Guitar Pedal

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -476,3 +476,4 @@ PID    | Product name
 0x81D4 | Meocap Receiver - UF2 Bootloader
 0x81D5 | HSBL-ko-gyo HSBL-S100 Chameleon Key
 0x81D6 | HSBL-ko-gyo HSBL-S100 Chameleon Key - UF2 Bootloader
+0x81D7 | Kailani Reverb Black Edition - VTR Effects


### PR DESCRIPTION
Guitar Reverb Pedal, using the ESP32-S2. I need the PID on behalf of VTR Effects as we are developing our software to control the pedal via USB communication.

https://vtreffects.com.br/produto/kailani-reverb-gold-series/