### PR TITLE
Add M5Stack Cardputer PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -478,3 +478,6 @@ PID    | Product name
 0x81D6 | HSBL-ko-gyo HSBL-S100 Chameleon Key - UF2 Bootloader
 0x81D7 | Kailani Reverb Black Edition - VTR Effects
 0x81D8 | CCLLC Sensor Mesh Node
+0x81D9 | M5STACK Cardputer - Arduino
+0x81DA | M5STACK Cardputer - CircuitPython
+0x81DB | M5STACK Cardputer - UF2 Bootloader


### PR DESCRIPTION
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)
A development board with keyboard, display and battery

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3FN8

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
TinyUF2 and CircuitPython require unique PIDs for any new boards added. I'm also adding an Arduino PID.

### If you're requesting a PID on behalf of a company, please mention the name of the company
M5Stack

### If applicable/available, a website or other URL with information about your product or company
https://docs.m5stack.com/en/core/Cardputer