### PR TITLE
0x81DG | QRP Labs - LightTracker Plus

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -485,3 +485,4 @@ PID    | Product name
 0x81DD | M5STACK Dial - CircuitPython
 0x81DE | M5STACK Dial - UF2 Bootloader
 0x81DF | GREYNUT - BUSY TAG
+0x81DG | QRP Labs - LightTracker Plus


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
* 1 Watt LoRa GPS Tracker for HAM operators 

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
* ESP32-S3 Mini

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
* Custom design & build

If you're requesting a PID on behalf of a company, please mention the name of the company
* QRP Labs

If applicable/available, a website or other URL with information about your product or company
* https://github.com/lightaprs/LightTracker-Plus-1.0
* https://shop.qrp-labs.com/aprs