### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -485,3 +485,7 @@ PID    | Product name
 0x81DD | M5STACK Dial - CircuitPython
 0x81DE | M5STACK Dial - UF2 Bootloader
 0x81DF | GREYNUT - BUSY TAG
+0x81E0 | SimKTech - SF1000
+0x81E1 | SimKTech - Evo Plus
+0x81E2 | SimKTech - Evo
+0x81E3 | SimKTech - 488


### PR DESCRIPTION
Description: USB and wireless gamepad support for simracing steering wheels

Four different variants needed:
- SF1000
- Evo Plus
- Evo
- 488

Based on ESP32-S3.

Custom PID needed for:
- full gamepad support without interference with any other existing devices
- differentiation between the four devices (different features)
- correct device description in the Windows game controler panel (joy.cpl)

Company:
SimKTech (1 person only), no website available yet 