### PR TITLE
 Add PIDs for ESP32-S2 VTR Effects Guitar Pedal - Narciso Black

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -490,3 +490,4 @@ PID    | Product name
 0x81E2 | SimKTech - Evo Plus
 0x81E3 | SimKTech - Evo
 0x81E4 | SimKTech - 488
+0x81E5 | Narciso Delay Black Edition - VTR Effects


### PR DESCRIPTION
Guitar Delay Pedal, using the ESP32-S2. I need the PID on behalf of VTR Effects as we are developing our software to control the pedal via USB communication.

https://vtreffects.com.br/produto/narciso-delay/
