### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -495,3 +495,4 @@ PID    | Product name
 0x81E7 | MRC Nexxt Command Station
 0x81E8 | MRC Nexxt Throttle
 0x81E9 | MRC Nexxt Booster
+0x81EA | Waveshare ESP32-S3-GEEK - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -491,3 +491,7 @@ PID    | Product name
 0x81E3 | SimKTech - Evo
 0x81E4 | SimKTech - 488
 0x81E5 | Narciso Delay Black Edition - VTR Effects
+0x81E6 | MRC Nexxt Gateway
+0x81E7 | MRC Nexxt Command Station
+0x81E8 | MRC Nexxt Throttle
+0x81E9 | MRC Nexxt Booster


### PR DESCRIPTION
### A short description of what the device is going to do (e.g. cat tracker with USB trace download)
This is a [new board from Waveshare](https://www.waveshare.com/wiki/ESP32-S3-GEEK), and I need a unique VID/PID in order to add CircuitPython support for the board. I'm not affiliated with Waveshare in any way, just a hobbyist. 

### What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3

### Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
It is required by the CircuitPython project

### If you're requesting a PID on behalf of a company, please mention the name of the company
N/A

### If applicable/available, a website or other URL with information about your product or company
N/A