### PR TITLE
Add PaxoPhone

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -497,3 +497,4 @@ PID    | Product name
 0x81E9 | MRC Nexxt Booster
 0x81EA | Waveshare ESP32-S3-GEEK - CircuitPython
 0x81EB | BlueRetro - X BT adapter
+0x81EC | PaxoPhone - Paxo


### PR DESCRIPTION
I am filing this request on behalf of the [Paxo open source project](https://github.com/paxo-phone), as one of the lead developers.

The device we are currently developing is a low-cost DIY phone powered by the simple ESP32 chip. This device can be built for a total cost of around 40$. It will support 4G networking, Wi-Fi, and third party apps through an app marketplace available online.

We would need a custom PID for the device to be identified and filtered by WebSerial on the app marketplace, for 3rd-party app installations.

You can learn more about the Paxo Project on [our Github page](https://github.com/paxo-phone) and on our [website](https://paxo.fr) (which is still in construction, some pages may not be available in English). As the project is community-driven and educationally oriented, you may can also check our [Discord server](https://discord.gg/84Qsp6tUSK).

If you want to reach out to me personally, you can do so by emailing me at [sysadmin@paxo.fr](mailto:sysadmin@paxo.fr) or through Discord at `@darkbrines`.