### PR TITLE
Allocate PIDs for LILYGO T-Keyboard S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -497,3 +497,7 @@ PID    | Product name
 0x81E9 | MRC Nexxt Booster
 0x81EA | Waveshare ESP32-S3-GEEK - CircuitPython
 0x81EB | BlueRetro - X BT adapter
+0x81EC | LILYGO T-Keyboard-S3 - Arduino
+0x81ED | LILYGO T-Keyboard-S3 - CircuitPython
+0x81EE | LILYGO T-Keyboard-S3 - MicroPython
+0x81EF | LILYGO T-Keyboard-S3 - UF2 Bootloader


### PR DESCRIPTION
> A short description of what the device is going to do (e.g. cat tracker with USB trace download)

T-Keyboard-S3 is an intelligent key controller developed based on the ESP32-S3-WROOM-1 module. It is different from traditional controllers as it features a 0.85-inch 128x128 RGB pixel LCD screen above the keys. It is connected to the main control board of the baseboard through an FPC ribbon cable.
https://www.lilygo.cc/products/t-keyboard-s3

> What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)

ESP32-S3

> Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)

Adding supported builds for MicroPython and CircuitPython.

> If you're requesting a PID on behalf of a company, please mention the name of the company

Requesting on behalf of LILYGO

> If applicable/available, a website or other URL with information about your product or company

https://www.lilygo.cc/products/t-keyboard-s3
https://github.com/Xinyuan-LilyGO/T-Keyboard-S3
