### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -509,6 +509,4 @@ PID    | Product name
 0x81F5 | KairoTech - Sound Voltex Controller
 0x81F6 | KairoTech - PSoC Flasher
 0x81F7 | KairoTech - Universal IO
-0x81F8 | KairoTech - Reserved
-0x81F9 | KairoTech - Reserved
 

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -501,3 +501,14 @@ PID    | Product name
 0x81ED | LILYGO T-Keyboard-S3 - CircuitPython
 0x81EE | LILYGO T-Keyboard-S3 - MicroPython
 0x81EF | LILYGO T-Keyboard-S3 - UF2 Bootloader
+0x81F0 | KairoTech - Arcade Card Reader
+0x81F1 | KairoTech - CHUNITHM Controller
+0x81F2 | KairoTech - ONGEKI Controller
+0x81F3 | KairoTech - maimaiDX Controller
+0x81F4 | KairoTech - beatmania IIDX Controller
+0x81F5 | KairoTech - Sound Voltex Controller
+0x81F6 | KairoTech - PSoC Flasher
+0x81F7 | KairoTech - Universal IO
+0x81F8 | KairoTech - Reserved
+0x81F9 | KairoTech - Reserved
+


### PR DESCRIPTION
一系列家用游戏机人机交互设备，主要为音乐游戏硬件，全部使用ESP32-S3，由于在WebHID和上位机中使用VID/PID识别设备，因此不能使用默认的ID，多数设备还在开发中，目前已经开始销售的产品链接如下：https://m.tb.cn/h.g199NHx?tk=9XapWtmkvA1