### PR TITLE
Add new entry for ESP32-S3-Tiny

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -509,4 +509,5 @@ PID    | Product name
 0x81F5 | KairoTech - Sound Voltex Controller
 0x81F6 | KairoTech - PSoC Flasher
 0x81F7 | KairoTech - Universal IO
+0x81F8 | Waveshare ESP32-S3-Tiny - CircuitPython
 


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
This is a [new board from Waveshare](https://www.waveshare.com/wiki/ESP32-S3-Tiny), and I need a unique VID/PID in order to add CircuitPython support for the board. I'm not affiliated with Waveshare in any way, just a hobbyist.

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S3

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
It is required by the CircuitPython project

If you're requesting a PID on behalf of a company, please mention the name of the company
N/A

If applicable/available, a website or other URL with information about your product or company
N/A