### PR TITLE
Add SkysyLight to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -510,4 +510,5 @@ PID    | Product name
 0x81F6 | KairoTech - PSoC Flasher
 0x81F7 | KairoTech - Universal IO
 0x81F8 | Waveshare ESP32-S3-Tiny - CircuitPython
-
+0x81F9 | Wirmo SkysyLight ESP32-S2 - Busylight
+0x81FA | Wirmo SkysyLight ESP32-S2 - UF2 Bootloader


### PR DESCRIPTION
I would like to request two PIDs on behalf of my Company `Wirmo` for a product called `SkysyLight`. One PID will be for the product and the other for the UF2 Bootloader.

Chip: ESP32-S2

Busylight: This will allow the PC software to uniquely identify the product to communicate with it.
UF2: This will allow for software updates

Company Website: https://wirmo.de