### PR TITLE
Add EMCFFB

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -512,3 +512,4 @@ PID    | Product name
 0x81F8 | Waveshare ESP32-S3-Tiny - CircuitPython
 0x81F9 | Wirmo SkysyLight ESP32-S2 - Busylight
 0x81FA | Wirmo SkysyLight ESP32-S2 - UF2 Bootloader
+0x81FB | EMC - EMCFFB


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
USBHID Joystick with Force Feedback interface

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
It is required for PC App software communication

If you're requesting a PID on behalf of a company, please mention the name of the company
N/A

If applicable/available, a website or other URL with information about your product or company
N/A