### PR TITLE
Added 2 new UM boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -512,3 +512,9 @@ PID    | Product name
 0x81F8 | Waveshare ESP32-S3-Tiny - CircuitPython
 0x81F9 | Wirmo SkysyLight ESP32-S2 - Busylight
 0x81FA | Wirmo SkysyLight ESP32-S2 - UF2 Bootloader
+0x81FB | Unexpected Maker FeatherS3 Neo - Arduino
+0x81FC | Unexpected Maker FeatherS3 Neo - CircuitPython
+0x81FD | Unexpected Maker FeatherS3 Neo - UF2 Bootloader
+0x81FE | Unexpected Maker RGBTouch Mini - Arduino
+0x81FF | Unexpected Maker RGBTouch Mini - CircuitPython
+0x8200 | Unexpected Maker RGBTouch Mini - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 6x PIDs for 2 new boards from Unexpected Maker.

One each for CircuitPython, Arduino and the UF2 Bootloader

My first board is my new FeatherS3 Neo which is  an ESP32-S3 based Feather format board that has a 7x7 RGB LED matrix on it.
![FeatherS3 Neo Preview](https://github.com/espressif/usb-pids/assets/3156212/206b0f6e-ba5a-40ca-b0b2-cc49e2a52032)


The second board is something new and very cool that I can't really go into publicly `yet`, but it's ESP32-S3 based, with a lot of RGB and other cool stuff, but here's a tease...
https://x.com/unexpectedmaker/status/1779077577946411154

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf of my Company, Unexpected Maker

Thanks :)