### PR TITLE
Add UMD to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -512,3 +512,4 @@ PID    | Product name
 0x81F8 | Waveshare ESP32-S3-Tiny - CircuitPython
 0x81F9 | Wirmo SkysyLight ESP32-S2 - Busylight
 0x81FA | Wirmo SkysyLight ESP32-S2 - UF2 Bootloader
+0x81FB | UMD - Logger


### PR DESCRIPTION
- We are developing a product which has shows up as having 2 USB ports, one for an application and one for logging. On our customer facing configuration website [link](https://umd.com.au/m320/), we need an additional PID to filter on, such that customers' do not see the additional port when selecting a device.
- ESP32-S3
- We need a custom PID as we are writing a custom 
- Applying on the behalf of Unique Micro Design (UMD)
- Website [link](https://umd.com.au/)