### PR TITLE
Add PIDs for LilyGO T3-S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -527,3 +527,6 @@ PID    | Product name
 0x8207 | modue® One Touch - bootloader
 0x8208 | modue® One XLR - main
 0x8209 | modue® One XLR - bootloader
+0x820A | LilyGO T3-S3 - Arduino
+0x820B | LilyGO T3-S3 - CircuitPython/Micropython
+0x820C | LilyGO T3-S3 - UF2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. Development board with LoRa radio, 128x64 OLED display and micro-SD card adapter
2. ESPRESSIF ESP32-S3FH4R2
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. LilyGO
5. https://www.lilygo.cc/products/t3s3-v1-0

Please, let me know if you require any additional information!