### PR TITLE
Add PID for ESP32-S3 Esp-fwtool

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -21,3 +21,4 @@ PID    | Product name
 0x700D | ESP32-S3 Box Lite - CircuitPython
 0x700E | ESP32-S3-EYE - UF2 Bootloader
 0x700F | ESP32-S3-EYE - CircuitPython
+0x7010 | ESP32-S3 Esp-fwtool - Esp fwtool


### PR DESCRIPTION
- ESP burner based on ESP32-S3
- ESP32-S3R2
- Identify the device by unique PID
- Espressif