### PR TITLE
Add PIDS for Lilygo T4-S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -207,6 +207,7 @@ PID    | Product name
 0x80C7 | Lolin S2 Pico - UF2 Bootloader
 0x80C8 | BrainBoardz Neuron - CircuitPython
 0x80C9 | BrainBoardz NeuronZ - CircuitPython
+0x80CA | BrainBoardz Neuron - Arduino
 0x80CB | BrainBoardz NeuronZ - Arduino
 0x80CC | BrainBoardz Neuron - UF2 Bootloader
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
@@ -250,7 +251,6 @@ PID    | Product name
 0x80F3 | WERMA Signaltechnik GmbH + Co. KG - eSIGN
 0x80F4 | WERMA Signaltechnik GmbH + Co. KG - eSIGN Bootloader
 0x80F5 | Lolin C3 Mini - CircuitPython
-0x80CA | BrainBoardz Neuron - Arduino
 0x80F6 | Unexpected Maker - Reflow Master Pro
 0x80F7 | Siemens - ECS
 0x80F8 | Cytron Maker Feather AIoT S3 - Arduino

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -207,7 +207,6 @@ PID    | Product name
 0x80C7 | Lolin S2 Pico - UF2 Bootloader
 0x80C8 | BrainBoardz Neuron - CircuitPython
 0x80C9 | BrainBoardz NeuronZ - CircuitPython
-0x80CA | BrainBoardz Neuron - Arduino
 0x80CB | BrainBoardz NeuronZ - Arduino
 0x80CC | BrainBoardz Neuron - UF2 Bootloader
 0x80CD | BrainBoardz NeuronZ - UF2 Bootloader
@@ -251,6 +250,7 @@ PID    | Product name
 0x80F3 | WERMA Signaltechnik GmbH + Co. KG - eSIGN
 0x80F4 | WERMA Signaltechnik GmbH + Co. KG - eSIGN Bootloader
 0x80F5 | Lolin C3 Mini - CircuitPython
+0x80CA | BrainBoardz Neuron - Arduino
 0x80F6 | Unexpected Maker - Reflow Master Pro
 0x80F7 | Siemens - ECS
 0x80F8 | Cytron Maker Feather AIoT S3 - Arduino
@@ -536,3 +536,6 @@ PID    | Product name
 0x8210 | LILYGO T-Display-S3-Pro - Arduino
 0x8211 | LILYGO T-Display-S3-Pro - CircuitPython
 0x8212 | LILYGO T-Display-S3-Pro - UF2 Bootloader
+0x8213 | LILYGO T4-S3 - Arduino
+0x8214 | LILYGO T4-S3 - CircuitPython
+0x8215 | LILYGO T4-S3 - UF2 Bootloader


### PR DESCRIPTION
This  PR is for the Lilygo T4-S3 board
1. Espressif ESP32-S3R8
2. Adafruit requires unique PIDs for Circuitpython, TinyUF2 and Arduino
3. https://github.com/Xinyuan-LilyGO/LilyGo-AMOLED-Series
    https://www.lilygo.cc/en-ca/products/t4-s3
    