### PR TITLE
Add PIDS for LOLIN S3 Mini Pro

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -539,3 +539,6 @@ PID    | Product name
 0x8213 | LILYGO T4-S3 - Arduino
 0x8214 | LILYGO T4-S3 - CircuitPython
 0x8215 | LILYGO T4-S3 - UF2 Bootloader
+0x8216 | LOLIN S3 Mini Pro - Arduino
+0x8217 | LOLIN S3 Mini Pro - CircuitPython
+0x8218 | LOLIN S3 Mini Pro - UF2 Bootloader


### PR DESCRIPTION
This PR is for the LOLIN S3 Mini Pro

1. Espressif ESP32-S3FH4R2
2. Requires unique PIDs for Circuitpython, TinyUF2 and Arduino
3. https://www.wemos.cc/en/latest/s3/s3_mini_pro.html
