### PR TITLE
Added new PID for MC55 Touch Smart by WERMA Signaltechnik GmbH + Co.KG

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -542,3 +542,4 @@ PID    | Product name
 0x8216 | LOLIN S3 Mini Pro - Arduino
 0x8217 | LOLIN S3 Mini Pro - CircuitPython
 0x8218 | LOLIN S3 Mini Pro - UF2 Bootloader
+0x8219 | WERMA Signaltechnik GmbH + Co. KG - MC55 Touch Smart


### PR DESCRIPTION
Hi, I would like to register a PID for our new Product

A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Industial Signal Device 

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
The PIDs are required so that the PC Software can detect the product

If you're requesting a PID on behalf of a company, please mention the name of the company
WERMA Signaltechnik GmbH + Co. KG

If applicable/available, a website or other URL with information about your product or company
https://www.werma.com/de/