### PR TITLE
Added Unexpected Maker OMGS3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -553,3 +553,6 @@ PID    | Product name
 0x8221 | Waveshare ESP32-S3-LCD-1.69 - Arduino
 0x8222 | Waveshare ESP32-S3-LCD-1.69 - CircuitPython/MicroPython
 0x8223 | Waveshare ESP32-S3-LCD-1.69 - UF2 Bootloader
+0x8224 | Unexpected Maker OMGS3 - Arduino
+0x8225 | Unexpected Maker OMGS3 - CircuitPython/MicroPython
+0x8226 | Unexpected Maker OMGS3 - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 3x PIDs for my new OMGS3 Board

One each for CircuitPython/MicroPython, Arduino and the UF2 Bootloader

OMGS3 is the smallest ESP32-S3 based fully featured board/module in the world - at just 25x10mm in size.
https://unexpectedmaker.com/omgs3

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf of my Company, Unexpected Maker

Thanks :)