### PR TITLE
Add pid for ATLNS Flasher

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -556,3 +556,4 @@ PID    | Product name
 0x8224 | Unexpected Maker OMGS3 - Arduino
 0x8225 | Unexpected Maker OMGS3 - CircuitPython/MicroPython
 0x8226 | Unexpected Maker OMGS3 - UF2 Bootloader
+0x8227 | ATLNS Flasher


### PR DESCRIPTION
ATLNS Flasher

ESP32-S3

Need a unique PID to identify the device.

ATLNS Semiconductor Technology (Xiamen) Co., LTD

https://www.atlns.cn/
