### PR TITLE
Add PIDs for Waveshare ESP32-S3-Zero

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -556,3 +556,6 @@ PID    | Product name
 0x8224 | Unexpected Maker OMGS3 - Arduino
 0x8225 | Unexpected Maker OMGS3 - CircuitPython/MicroPython
 0x8226 | Unexpected Maker OMGS3 - UF2 Bootloader
+0x8227 | Waveshare ESP32-S3-Zero - Arduino
+0x8228 | Waveshare ESP32-S3-Zero - CircuitPython/MicroPython
+0x8229 | Waveshare ESP32-S3-Zero - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -556,6 +556,6 @@ PID    | Product name
 0x8224 | Unexpected Maker OMGS3 - Arduino
 0x8225 | Unexpected Maker OMGS3 - CircuitPython/MicroPython
 0x8226 | Unexpected Maker OMGS3 - UF2 Bootloader
-0x8227 | Waveshare ESP32-S3-Zero - Arduino
-0x8228 | Waveshare ESP32-S3-Zero - CircuitPython/MicroPython
-0x8229 | Waveshare ESP32-S3-Zero - UF2 Bootloader
+0x822B | Waveshare ESP32-S3-Zero - Arduino
+0x822C | Waveshare ESP32-S3-Zero - CircuitPython/MicroPython
+0x822D | Waveshare ESP32-S3-Zero - UF2 Bootloader


### PR DESCRIPTION
Adding PID for Waveshare ESP32-S3-Zero board to be added to CircuitPython, arduino-esp32 and PlatformIO.

Product wiki: [ESP32-S3-Zero](https://www.waveshare.com/wiki/ESP32-S3-Zero)
