### PR TITLE
Waveshare Added PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -566,15 +566,15 @@ PID    | Product name
 0x822E | Waveshare ESP32-S3-Touch-LCD-4.3 - Arduino
 0x822F | Waveshare ESP32-S3-Touch-LCD-4.3 - CircuitPython/MicroPython
 0x8230 | Waveshare ESP32-S3-Touch-LCD-4.3 - UF2 Bootloader
-0x822E | Waveshare ESP32-S3-Touch-LCD-4.3B - Arduino
-0x822F | Waveshare ESP32-S3-Touch-LCD-4.3B - CircuitPython/MicroPython
-0x8230 | Waveshare ESP32-S3-Touch-LCD-4.3B - UF2 Bootloader
-0x822E | Waveshare ESP32-S3-Touch-LCD-7 - Arduino
-0x822F | Waveshare ESP32-S3-Touch-LCD-7 - CircuitPython/MicroPython
-0x8230 | Waveshare ESP32-S3-Touch-LCD-7 - UF2 Bootloader
-0x822E | Waveshare ESP32-S3-Touch-LCD-5 - Arduino
-0x822F | Waveshare ESP32-S3-Touch-LCD-5 - CircuitPython/MicroPython
-0x8230 | Waveshare ESP32-S3-Touch-LCD-5 - UF2 Bootloader
-0x822E | Waveshare ESP32-S3-Touch-LCD-5B - Arduino
-0x822F | Waveshare ESP32-S3-Touch-LCD-5B - CircuitPython/MicroPython
-0x8230 | Waveshare ESP32-S3-Touch-LCD-5B - UF2 Bootloader
+0x8231 | Waveshare ESP32-S3-Touch-LCD-4.3B - Arduino
+0x8232 | Waveshare ESP32-S3-Touch-LCD-4.3B - CircuitPython/MicroPython
+0x8233 | Waveshare ESP32-S3-Touch-LCD-4.3B - UF2 Bootloader
+0x8234 | Waveshare ESP32-S3-Touch-LCD-7 - Arduino
+0x8235 | Waveshare ESP32-S3-Touch-LCD-7 - CircuitPython/MicroPython
+0x8236 | Waveshare ESP32-S3-Touch-LCD-7 - UF2 Bootloader
+0x8237 | Waveshare ESP32-S3-Touch-LCD-5 - Arduino
+0x8238 | Waveshare ESP32-S3-Touch-LCD-5 - CircuitPython/MicroPython
+0x8239 | Waveshare ESP32-S3-Touch-LCD-5 - UF2 Bootloader
+0x823A | Waveshare ESP32-S3-Touch-LCD-5B - Arduino
+0x823B | Waveshare ESP32-S3-Touch-LCD-5B - CircuitPython/MicroPython
+0x823C | Waveshare ESP32-S3-Touch-LCD-5B - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -563,3 +563,18 @@ PID    | Product name
 0x822B | Waveshare ESP32-S3-Zero - Arduino
 0x822C | Waveshare ESP32-S3-Zero - CircuitPython/MicroPython
 0x822D | Waveshare ESP32-S3-Zero - UF2 Bootloader
+0x822E | Waveshare ESP32-S3-Touch-LCD-4.3 - Arduino
+0x822F | Waveshare ESP32-S3-Touch-LCD-4.3 - CircuitPython/MicroPython
+0x8230 | Waveshare ESP32-S3-Touch-LCD-4.3 - UF2 Bootloader
+0x822E | Waveshare ESP32-S3-Touch-LCD-4.3B - Arduino
+0x822F | Waveshare ESP32-S3-Touch-LCD-4.3B - CircuitPython/MicroPython
+0x8230 | Waveshare ESP32-S3-Touch-LCD-4.3B - UF2 Bootloader
+0x822E | Waveshare ESP32-S3-Touch-LCD-7 - Arduino
+0x822F | Waveshare ESP32-S3-Touch-LCD-7 - CircuitPython/MicroPython
+0x8230 | Waveshare ESP32-S3-Touch-LCD-7 - UF2 Bootloader
+0x822E | Waveshare ESP32-S3-Touch-LCD-5 - Arduino
+0x822F | Waveshare ESP32-S3-Touch-LCD-5 - CircuitPython/MicroPython
+0x8230 | Waveshare ESP32-S3-Touch-LCD-5 - UF2 Bootloader
+0x822E | Waveshare ESP32-S3-Touch-LCD-5B - Arduino
+0x822F | Waveshare ESP32-S3-Touch-LCD-5B - CircuitPython/MicroPython
+0x8230 | Waveshare ESP32-S3-Touch-LCD-5B - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -578,3 +578,6 @@ PID    | Product name
 0x823A | Waveshare ESP32-S3-Touch-LCD-5B - Arduino
 0x823B | Waveshare ESP32-S3-Touch-LCD-5B - CircuitPython/MicroPython
 0x823C | Waveshare ESP32-S3-Touch-LCD-5B - UF2 Bootloader
+0x823D | Waveshare ESP32-S3-Touch-LCD-4 - Arduino
+0x823E | Waveshare ESP32-S3-Touch-LCD-4 - CircuitPython/MicroPython
+0x823F | Waveshare ESP32-S3-Touch-LCD-4 - UF2 Bootloader


### PR DESCRIPTION
Added ESP32-S3-Touch-LCD-4.3, ESP32-S3-Touch-LCD-4.3B, ESP32-S3-Touch-LCD-7, ESP32-S3-Touch-LCD-5, ESP32-S3-Touch-LCD -5B and ESP32-S3-Touch-LCD -4 PID
wiki:
1.[ESP32-S3-Touch-LCD-4.3](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3)
2.[ESP32-S3-Touch-LCD-4.3B](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3B)
3.[ESP32-S3-Touch-LCD-7](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-7)
4.[ESP32-S3-Touch-LCD-5](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
5.[ESP32-S3-Touch-LCD-5B](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
6.[ESP32-S3-Touch-LCD-4](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4)
