### PR TITLE
add Waveshare ESP32-S3-Touch-AMOLED-2.41

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -583,3 +583,4 @@ PID    | Product name
 0x823F | Waveshare ESP32-S3-Touch-LCD-4 - UF2 Bootloader
 0x8240 | kohacraft.com Padauk Programmer - Arduino
 0x8241 | EASYBCI Bio Amp 1
+0x8241 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - Arduino

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -583,4 +583,4 @@ PID    | Product name
 0x823F | Waveshare ESP32-S3-Touch-LCD-4 - UF2 Bootloader
 0x8240 | kohacraft.com Padauk Programmer - Arduino
 0x8241 | EASYBCI Bio Amp 1
-0x8241 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - Arduino
+0x8242 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - Arduino


### PR DESCRIPTION
The device has not been officially released, and is mainly used for Internet of Things, automation and scalability products.PID is used for ESP32-S3,Company products, convenient to increase visibility,Company name: Waveshare.official website URL:https://www.waveshare.net/