### PR TITLE
Add PIDs for the ESP32-S3-Super-Mini

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -587,3 +587,6 @@ PID    | Product name
 0x8243 | Barduino 4 - Arduino
 0x8244 | Barduino 4 - CircuitPython/MicroPython
 0x8245 | Barduino 4 - UF2 Bootloader
+0x8246 | Aliexpress - ESP32-S3-Super-Mini - Arduino
+0x8247 | Aliexpress - ESP32-S3-Super-Mini - CircuitPython/MicroPython
+0x8248 | Aliexpress - ESP32-S3-Super-Mini - UF2 Bootloader


### PR DESCRIPTION
## Description

For a while there have been "ESP32-S3 Super Mini" Boards (with a "ESP32-S3FH4R2" chip) floating around on Aliexpress and other chinese marketplaces.
I couldn't find out who the original designer is, since all shops just use the same pictures and diagrams with different watermarks.
Apparently there are revisions with the open source logo on them, but even so I couldn't find any more infos on the board than on the shops and [this chinese site](https://www.nologo.tech/product/esp32/esp32s3supermini/esp32S3SuperMini.html).
If it's a clone, I couldn't find the original.

(They are often listed together with the C3-Super-Mini variants, which look like Waveshare clones, but they don't have a variant of the S3 Super Mini I could find anywhere)

All that is to say, I'd like to add this board to the usual places, so it can be used with Arduino and Micro-/CircuitPython without any guesswork for the users.


Since I couldn't make out a company, I put in "Aliexpress" as company name. 
Maybe we could discuss a "N/A" or "Generic", "OEM", "Knockoff" or something instead :)
