### PR TITLE
Add PIDs for  ESP32 S3 Super Mini

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -587,3 +587,6 @@ PID    | Product name
 0x8243 | Barduino 4 - Arduino
 0x8244 | Barduino 4 - CircuitPython/MicroPython
 0x8245 | Barduino 4 - UF2 Bootloader
+0x8246 | Generic ESP32-S3-Super-Mini - Arduino
+0x8247 | Generic ESP32-S3-Super-Mini - CircuitPython/MicroPython
+0x8248 | Generic ESP32-S3-Super-Mini - UF2 Bootloader


### PR DESCRIPTION
Re-Request with appropriate Template and updated "Manufacturer".

For traceability, this references #181, which was closed because of a pull request template issue and needed a change to the "manufacturer".

This is about the "ESP32-S3 Super Mini" dev boards found on Aliexpress and other chinese marketplaces.
Since no original manufacturer or creator could be found, I'm adding these as "Generic" brand, to be able to reference them in other projects for Arduino Core, Circuit-/MicroPython and TinyUF2.

They use the "ESP32-S3FH4R2" Variant without any additional USB-UART bridge and only rely on the internal 4MB Flash and 2MB PSRAM.

Some basic info can be found on [this chinese site](https://www.nologo.tech/product/esp32/esp32s3supermini/esp32S3SuperMini.html).


