### PR TITLE
Add PIDs for ESP32-S3-LCD-EV-Board v1.5

### DIFF
--- a/allocated-pids-espressif-devboards.txt
+++ b/allocated-pids-espressif-devboards.txt
@@ -21,3 +21,5 @@ PID    | Product name
 0x700D | ESP32-S3 Box Lite - CircuitPython
 0x700E | ESP32-S3-EYE - UF2 Bootloader
 0x700F | ESP32-S3-EYE - CircuitPython
+0x7010 | ESP32-S3-LCD-EV-Board v1.5 - UF2 Bootloader
+0x7011 | ESP32-S3-LCD-EV-Board v1.5 - CircuitPython


### PR DESCRIPTION
more detail for [ESP32-S3-LCD-EV-Board v1.5](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-lcd-ev-board/user_guide.html)