### PR TITLE
add Waveshare ESP32-S3-Touch-AMOLED-1.91, Waveshare ESP32-S3-Touch-AMOLED-1.64, and Waveshare ESP32-S3-Touch-AMOLED-1.43

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -590,3 +590,6 @@ PID    | Product name
 0x8246 | Generic ESP32-S3-Super-Mini - Arduino
 0x8247 | Generic ESP32-S3-Super-Mini - CircuitPython/MicroPython
 0x8248 | Generic ESP32-S3-Super-Mini - UF2 Bootloader
+0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
+0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
+0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino


### PR DESCRIPTION
I have made some adjustments. These models are the ones our company will be working on next. Upon project completion, they will be named accordingly and uploaded to the wiki. You can check our official website at: https://www.waveshare.net/