### PR TITLE
Add model ESP32-S3-LCD-1.47 ...

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,3 +593,13 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
+0x824C | Waveshare ESP32-C6-Zero - Arduino
+0x824D | Waveshare ESP32-S3-LCD-1.47 - Arduino
+0x824E | Waveshare ESP32-C6-LCD-1.47 - Arduino
+0x824F | Waveshare ESP32-S3-LCD-1.85 - Arduino
+0x8250 | Waveshare ESP32-S3-Touch-LCD-1.46 - Arduino
+0x8251 | Waveshare ESP32-S3-Touch-LCD-1.85 - Arduino
+0x8252 | Waveshare ESP32-S3-Touch-LCD-2.1 - Arduino
+0x8253 | Waveshare ESP32-S3-Touch-LCD-2.8 - Arduino
+0x8254 | Waveshare ESP32-S3-Touch-LCD-2.8B - Arduino
+0x8255 | Waveshare ESP32-S3-Touch-LCD-2.8C - Arduino


### PR DESCRIPTION
Waveshare ESP32-C6-Zero
Waveshare ESP32-S3-LCD-1.47
Waveshare ESP32-C6-LCD-1.47
Waveshare ESP32-S3-LCD-1.85
Waveshare ESP32-S3-Touch-LCD-1.46
Waveshare ESP32-S3-Touch-LCD-1.85
Waveshare ESP32-S3-Touch-LCD-2.1
Waveshare ESP32-S3-Touch-LCD-2.8
Waveshare ESP32-S3-Touch-LCD-2.8B 
Waveshare ESP32-S3-Touch-LCD-2.8C

Add these models for better publicity