### PR TITLE
add new board: CircuitArt ESP32S3 CamTFT

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,3 +593,6 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
+0x8256 | CircuitArt ESP32S3 CamTFT - Arduino
+0x8257 | CircuitArt ESP32S3 CamTFT - UF2 Bootloader
+0x8258 | CircuitArt ESP32S3 CamTFT - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,6 +593,6 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
-0x8256 | CircuitArt ESP32S3 CamTFT - Arduino
-0x8257 | CircuitArt ESP32S3 CamTFT - UF2 Bootloader
-0x8258 | CircuitArt ESP32S3 CamTFT - CircuitPython
+0x824C | CircuitArt ESP32S3 CamTFT - Arduino
+0x824D | CircuitArt ESP32S3 CamTFT - UF2 Bootloader
+0x824E | CircuitArt ESP32S3 CamTFT - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,6 +593,6 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
-0x824C | CircuitArt ESP32S3 CamTFT - Arduino
-0x824D | CircuitArt ESP32S3 CamTFT - UF2 Bootloader
-0x824E | CircuitArt ESP32S3 CamTFT - CircuitPython
+0x824F | CircuitArt ESP32S3 CamTFT - Arduino
+0x8250 | CircuitArt ESP32S3 CamTFT - UF2 Bootloader
+0x8251 | CircuitArt ESP32S3 CamTFT - CircuitPython


### PR DESCRIPTION
add new board: CircuitArt ESP32S3 CamTFT

This device has not been officially released and is mainly used for educational purposes. 
It uses the ESP32S3 chip. 
Custom PIDs are required to have it officially recognized on the CircuitPython website and to create an Arduino core for it, as well as a tinyUF2 bootloader.

more details: https://github.com/CircuitART/ESP32S3CamTFT/tree/main
Thanks