### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,3 +593,4 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
+0x824C | HE-FMX digital thickness gauge - Marconilab


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download)
-Digital thicness gauge, mesure the thicness of surfaces

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
- ESP32 C3

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
-The device has software running on pc and need to be paired as a plug and play device

If you're requesting a PID on behalf of a company, please mention the name of the company
-Marconilab srl