### PR TITLE
added CharaChorder Two S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,3 +593,5 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
+0x824C | CharaChorder Two S3
+0x824D | CharaChorder Two S3 - UF2 Bootloader


### PR DESCRIPTION
CharaChorder Two S3 is a chording enabled USB keyboard.
ESP32-S3
The device pairs with serial applications that need PIDs for filtering valid devices
CharaChorder, LLC
The produce page is not live yet, but will be here:
https://www.charachorder.com/products/charachorder-two