### PR TITLE
Add PID 0x8258 | Piston Medical - BLE Heart Rate Monitor Adapter

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -605,3 +605,4 @@ PID    | Product name
 0x8255 | Waveshare ESP32-S3-Touch-AMOLED-1.8 - Arduino
 0x8256 | Waveshare ESP32-S3-Touch-AMOLED-1.8 - CircuitPython/MicroPython
 0x8257 | Waveshare ESP32-S3-TOUCH-AMOLED-1.8 - UF2 Bootloader
+0x8258 | Piston Medical - BLE Heart Rate Monitor Adapter


### PR DESCRIPTION
Add PID 0x8258 | Piston Medical - BLE Heart Rate Monitor Adapter

- Give a short description of the device and its function, 
  + Device for transfer heart rate data from BLE HR sensor through USB
- Tell us what chip you're using, 
  + ESP32-S3
- Mention why you need a custom PID
  + Saját driver használata és a jobb felhasználói élmény miatt.
- If applicable/available mention your company and a link to the website of the product.
  + Piston Ltd. - Budapest - medical device manufacturer - https://www.pistonmedical.com/
