### PR TITLE
Add pid 0x8293 | Piston Medical - BLE Heart Rate Monitor Adapter

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -664,3 +664,4 @@ PID    | Product name
 0x8290 | Waveshare ESP32-S3-Touch-LCD-1.85 - Arduino
 0x8291 | Waveshare ESP32-S3-Touch-LCD-1.85 - CircuitPython/MicroPython
 0x8292 | Waveshare ESP32-S3-Touch-LCD-1.85 - UF2 Bootloader
+0x8293 | Piston Medical - BLE Heart Rate Monitor Adapter


### PR DESCRIPTION
- Give a short description of the device and its function, 
  + Device for transfer heart rate data from BLE HR sensor through USB
- Tell us what chip you're using, 
  + ESP32-S3
- Mention why you need a custom PID
  + For the use custom driver and a better user experience.
- If applicable/available mention your company and a link to the website of the product.
  + Piston Ltd. - Budapest - medical device manufacturer - https://www.pistonmedical.com/
