### PR TITLE
Add PID for cezerio dev ESP32C6

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -192,7 +192,7 @@ PID    | Product name
 0x80B8 | Morpheans MorphESP-240 - UF2 CircuitPython
 0x80B9 | Hypnocube - HypnoBall
 0x80BA | Hypnocube - HypnoLSD
-0x80BB | Hypnocube - HypnoCube8
+0x80BB | Hypnocube - HypnoCube8 
 0x80BC | Hypnocube - HypnoCube4
 0x80BD | Hypnocube - HypnoLights
 0x80BE | Hypnocube - HypnoSquare8
@@ -351,7 +351,7 @@ PID    | Product name
 0x8157 | MD-PLUG Type C
 0x8158 | MD-PLUG Type A
 0x8159 | Shrooly SH01 - UF2 Bootloader
-0x815A | Shrooly SH01 - Production Firmware
+0x815A | Shrooly SH01 - Production Firmware 
 0x815B | MicroStorm CORE_S3 - ProjectSource
 0x815C | Smart Bee Designs Bee Data Logger - Arduino
 0x815D | Smart Bee Designs Bee Data Logger - CircuitPython
@@ -376,7 +376,7 @@ PID    | Product name
 0x8170 | CaniotBox - Production Firmware
 0x8171 | 01Space ESP32-S3-0.42OLED - Arduino
 0x8172 | 01Space ESP32-S3-0.42OLED - CircuitPython
-0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython
+0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython 
 0x8174 | 01Space ESP32-S3-0.42OLED - UF2 Bootloader
 0x8175 | Talk All Sport - Base Station
 0x8176 | Talk All Sport - Hand Controller

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -670,3 +670,6 @@ PID    | Product name
 0x8296 | Work Louder - Knob1
 0x8297 | Work Louder - Creator Micro v2
 0x8298 | Work Louder - Creator Micro v2 - BLE
+0x8299 | cezerio dev ESP32C6 - Arduino
+0x829A | cezerio dev ESP32C6 - CircuitPython
+0x829B | cezerio dev ESP32C6 - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -432,7 +432,7 @@ PID    | Product name
 0x81A8 | Loki Modulation - VTR Effects
 0x81A9 | MagiClick S3 - Arduino
 0x81AA | MagiClick S3 - CircuitPython
-0x81AB | MagiClick S3 - MicroPython
+0x81AB | MagiClick S3 - MicroPython 
 0x81AC | MagiClick S3 - UF2 Bootloader
 0x81AD | Creekside S3 - Buzzer Receiver
 0x81AE | Creekside S3 - Buzzer

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -593,6 +593,3 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
-0x824C | cezerio Dev ESP32-C6 - Arduino
-0x824D | cezerio Dev ESP32-C6 - CircuitPython
-0x824E | cezerio Dev ESP32-C6 - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -192,7 +192,7 @@ PID    | Product name
 0x80B8 | Morpheans MorphESP-240 - UF2 CircuitPython
 0x80B9 | Hypnocube - HypnoBall
 0x80BA | Hypnocube - HypnoLSD
-0x80BB | Hypnocube - HypnoCube8 
+0x80BB | Hypnocube - HypnoCube8
 0x80BC | Hypnocube - HypnoCube4
 0x80BD | Hypnocube - HypnoLights
 0x80BE | Hypnocube - HypnoSquare8
@@ -351,7 +351,7 @@ PID    | Product name
 0x8157 | MD-PLUG Type C
 0x8158 | MD-PLUG Type A
 0x8159 | Shrooly SH01 - UF2 Bootloader
-0x815A | Shrooly SH01 - Production Firmware 
+0x815A | Shrooly SH01 - Production Firmware
 0x815B | MicroStorm CORE_S3 - ProjectSource
 0x815C | Smart Bee Designs Bee Data Logger - Arduino
 0x815D | Smart Bee Designs Bee Data Logger - CircuitPython
@@ -376,7 +376,7 @@ PID    | Product name
 0x8170 | CaniotBox - Production Firmware
 0x8171 | 01Space ESP32-S3-0.42OLED - Arduino
 0x8172 | 01Space ESP32-S3-0.42OLED - CircuitPython
-0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython 
+0x8173 | 01Space ESP32-S3-0.42OLED - MicroPython
 0x8174 | 01Space ESP32-S3-0.42OLED - UF2 Bootloader
 0x8175 | Talk All Sport - Base Station
 0x8176 | Talk All Sport - Hand Controller
@@ -432,7 +432,7 @@ PID    | Product name
 0x81A8 | Loki Modulation - VTR Effects
 0x81A9 | MagiClick S3 - Arduino
 0x81AA | MagiClick S3 - CircuitPython
-0x81AB | MagiClick S3 - MicroPython 
+0x81AB | MagiClick S3 - MicroPython
 0x81AC | MagiClick S3 - UF2 Bootloader
 0x81AD | Creekside S3 - Buzzer Receiver
 0x81AE | Creekside S3 - Buzzer
@@ -593,3 +593,6 @@ PID    | Product name
 0x8249 | Waveshare ESP32-S3-Touch-AMOLED-1.64 - Arduino
 0x824A | Waveshare ESP32-S3-Touch-AMOLED-1.43 - Arduino
 0x824B | Waveshare ESP32-S3-Touch-AMOLED-1.91 - Arduino
+0x824C | cezerio Dev ESP32-C6 - Arduino
+0x824D | cezerio Dev ESP32-C6 - CircuitPython
+0x824E | cezerio Dev ESP32-C6 - UF2 Bootloader


### PR DESCRIPTION
cezerio dev ESP32C6 is an development board based on Espressif ESP32-C6. 
Visit [webpage](https://cezerio.com/cezerio_dev_esp32c6) for detailed infos.
PID is neccesery for Arduino and Python.
