### PR TITLE
Add PIDs for RobotClass Graphite S3 board

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -678,6 +678,6 @@ PID    | Product name
 0x829E | Bantam Tools Serama Rooster ArtFrame XXL
 0x829F | Bantam Tools Serama Handwriter
 0x82A0 | Bantam Tools Serama 
-0x81A1 | RobotClass Graphite S3 - Arduino
-0x81A2 | RobotClass Graphite S3 - CircuitPython
-0x81A3 | RobotClass Graphite S3 - UF2 Bootloader
+0x82A1 | RobotClass Graphite S3 - Arduino
+0x82A2 | RobotClass Graphite S3 - CircuitPython
+0x82A3 | RobotClass Graphite S3 - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -678,3 +678,6 @@ PID    | Product name
 0x829E | Bantam Tools Serama Rooster ArtFrame XXL
 0x829F | Bantam Tools Serama Handwriter
 0x82A0 | Bantam Tools Serama 
+0x81A1 | RobotClass Graphite S3 - Arduino
+0x81A2 | RobotClass Graphite S3 - CircuitPython
+0x81A3 | RobotClass Graphite S3 - UF2 Bootloader


### PR DESCRIPTION
Graphite-S3 - board with lipo charger, APA102-2020 led and uninified I2C connector. This board is the next generation of the Graphite family of boards, featuring an ESP32-S3 SoC (previous version - Graphite-S2). Used for learning of IOT, Robotics and python programming (circuitpython). Inspired by the Sparkfun dev boards.

What chip are you using for the device the PID is allocated for (e.g. ESP32-S3)
ESP32-S3-WROOM-1-N8

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
use for arduino/circuitpython, device identification

If you're requesting a PID on behalf of a company, please mention the name of the company
RobotClass - We teach electronics and make our own hardware, hardware shop

If applicable/available, a website or other URL with information about your product or company
https://robotclass.ru/articles/graphites3/
