### PR TITLE
Add PID for OpenRemise - S3Main

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -682,3 +682,4 @@ PID    | Product name
 0x82A2 | RobotClass Graphite S3 - CircuitPython
 0x82A3 | RobotClass Graphite S3 - UF2 Bootloader
 0x82A4 | ENERTY Module M - UF2 Bootloader
+0x82A5 | OpenRemise - S3Main


### PR DESCRIPTION
Hello

I'm developing open source model railway hardware under the name OpenRemise. This development has been going on for 3 years now and has gone through several prototypes with different processors and drive circuits. Among other things, it has also contributed to me adding stub support for the [esp-serial-flasher](https://github.com/espressif/esp-serial-flasher) :smile:.

Anyhow, I'm about to launch the first fully integrated version of my command station in a couple of months, the `S3Main`.
![s3main](https://github.com/user-attachments/assets/63d25dde-a7ea-4a24-bf16-e52ce1635ba9)

I've already registered the domain [openremise.at](https://openremise.at/) but there is not a lot of information on it yet. The device could use its own PID to register with a PC software that loads software updates and sound projects into locomotive decoders.

Best regards
Vincent