### PR TITLE
Add PID for zigbee dongle

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -683,3 +683,4 @@ PID    | Product name
 0x82A3 | RobotClass Graphite S3 - UF2 Bootloader
 0x82A4 | ENERTY Module M - UF2 Bootloader
 0x82A5 | OpenRemise - S3Main
+0x82A6 | Espressif zigbee dongle


### PR DESCRIPTION
Please answer the questions in the README.md of this repo:

Give a short description of the device and its function: The universal Zigbee USB dongle works with popular Home Automation Systems.
Tell us what chip you're using: ESP32S3 and ESP32H4.
Mention why you need a custom PID: For USB serial communication to Windows/Ubuntu/Raspbian/Docker etc platforms.
If applicable/available mention your company and a link to the website of the product: None available.
