### PR TITLE
add ESP32-C6-Zero

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -658,9 +658,9 @@ PID    | Product name
 0x828A | Waveshare ESP32-S3-LCD-1.47 - Arduino
 0x828B | Waveshare ESP32-S3-LCD-1.47 - CircuitPython/MicroPython
 0x828C | Waveshare ESP32-S3-LCD-1.47 - UF2 Bootloader
-0x828D | Unallocated
-0x828E | Unallocated
-0x828F | Unallocated
+0x828D | Waveshare ESP32-C6-Zero - Arduino
+0x828E | Waveshare ESP32-C6-Zero - CircuitPython/MicroPython
+0x828F | Waveshare ESP32-C6-Zero - UF2 Bootloader
 0x8290 | Waveshare ESP32-S3-Touch-LCD-1.85 - Arduino
 0x8291 | Waveshare ESP32-S3-Touch-LCD-1.85 - CircuitPython/MicroPython
 0x8292 | Waveshare ESP32-S3-Touch-LCD-1.85 - UF2 Bootloader


### PR DESCRIPTION

- Give a short description of the device and its function
WaveShare ESP32-C6-Zero

- Tell us what chip you're using
ESP32-C6

- Mention why you need a custom PID
apply for Arduino ,CircuitPython/MicroPython and UF2 Bootloader for next step

- If applicable/available mention your company and a link to the website of the product.
[https://www.waveshare.com/wiki/ESP32-C6-Zero](https://www.waveshare.com/wiki/ESP32-C6-Zero)
