### PR TITLE
Add PID for Undalogic miniSMU MS01

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -683,3 +683,4 @@ PID    | Product name
 0x82A3 | RobotClass Graphite S3 - UF2 Bootloader
 0x82A4 | ENERTY Module M - UF2 Bootloader
 0x82A5 | OpenRemise - S3Main
+0x82A6 | Undalogic miniSMU MS01


### PR DESCRIPTION
- Give a short description of the device and its function
USB and WiFi source-measure unit for semiconductor characterisation

- Tell us what chip you're using,
ESP32-S3

- Mention why you need a custom PID
Custom driver & device identification through PID

- If applicable/available mention your company and a link to the website of the product.
Undalogic Ltd. (United Kingdom) - Test & Measurement equipment manufacturer - https://www.undalogic.com/