### PR TITLE
Add neway navpad

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -701,3 +701,7 @@ PID    | Product name
 0x82B5 | MIDI Dobrynya Pro V2 UF2 Bootloader
 0x82B6 | MIDI Dobrynya 32
 0x82B7 | MIDI Dobrynya 32 UF2 Bootloader
+0x82B9 | neway navpad controller v1 (boot)
+0x82BA | neway navpad controller v1
+0x82BB | neway navpad controller mini v1 (boot)
+0x82BC | neway navpad controller mini v1


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->

**Neway Navpad Controller [mini]**
<img src="https://github.com/user-attachments/assets/8f1a967c-bded-4f76-a9b5-2edf2df89db3" width="250">
Product in development, company website: https://www.newaydata.com

A USB-C peripheral to provide power, a joystick and physical buttons to a navigation tablet. We use an ESP32-S3 with TinyUSB but need to implement features beyond standard HID classes.
To enable us to create and certify a custom driver, we need custom PIDs. There are two variants, each with a bootloader.