### PR TITLE
Add PID for Enilinx Flexbar

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -706,3 +706,4 @@ PID    | Product name
 0x82BA | neway navpad controller v1
 0x82BB | neway navpad controller mini v1 (boot)
 0x82BC | neway navpad controller mini v1
+0x82BD | Enilinx™ Flexbar


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->
1. Flexbar is a versatile touch bar powered by the ESP32-S3, designed to provide functionality similar to the Apple Touch Bar. It has successfully raised $330K on Kickstarter.
![indegogo](https://github.com/user-attachments/assets/0c7400d5-0968-4dad-968b-711e39c6d638)
2. ESP32-S3
3. We need a custom PID for the accompanying software (FlexbarDesigner) to automatically recognize and connect to Flexbar.
4. ENIAC (HK) Technology Ltd.  深圳市本栖电子科技有限公司
5. https://eniacelec.com/   
    https://www.kickstarter.com/projects/1735591421/flexbar-a-versatile-and-fully-customizable-touch-bar-solution