### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -707,3 +707,4 @@ PID    | Product name
 0x82BB | neway navpad controller mini v1 (boot)
 0x82BC | neway navpad controller mini v1
 0x82BD | Enilinx™ Flexbar
+0x828E | SONULAB ESP32-S3 StompStation


### PR DESCRIPTION
PID for SONULAB StompStation audio device
- StompStation is a guitar stompbox based on ESP32-S3 processor
- Based on ESP32-S3-N8R8
- Need to be recognized for bootloader and firmware update app
- www.sonulab.com

<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->