### PR TITLE
Add PID for Enilinx Flexbar-CDC

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -708,3 +708,4 @@ PID    | Product name
 0x82BC | neway navpad controller mini v1
 0x82BD | Enilinx™ Flexbar
 0x82BE | SONULAB™ StompStation
+0x82BF | Enilinx™ Flexbar-CDC


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->
1. Flexbar-CDC is a versatile touch bar powered by the ESP32-S3, designed to provide functionality similar to the Apple Touch Bar.
2. ESP32-S3
3. **We need a new PID to distinguish between devices using the USB-HID protocol and those using the USB-CDC protocol.**
4. ENIAC (HK) Technology Ltd.  深圳市本栖电子科技有限公司
5. https://eniacelec.com/   
    https://www.kickstarter.com/projects/1735591421/flexbar-a-versatile-and-fully-customizable-touch-bar-solution