### PR TITLE
allocated pid 0x82C0 for Dinnosys LLC. - SpeakNGo

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -709,3 +709,4 @@ PID    | Product name
 0x82BD | Enilinx™ Flexbar
 0x82BE | SONULAB™ StompStation
 0x82BF | Enilinx™ Flexbar-CDC
+0x82C0 | Dinnosys Llc. - SpeakNGo


### PR DESCRIPTION
- Description: The device is a keyboard emulator, typing a text received from mobile phone.
- Chip: esp32-s3 
- Why need a custom PID: Want the device to appear in Device manager as custom device owned by the company.
- Company: Dinnosys LLC., Bulgaria. No web site available yet.