### PR TITLE
Allocate PIDs for LILYGO T-Dongle S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -710,3 +710,6 @@ PID    | Product name
 0x82BE | SONULAB™ StompStation
 0x82BF | Enilinx™ Flexbar-CDC
 0x82C0 | Dinnosys Llc. - SpeakNGo
+0x82C1 | LILYGO T-Dongle-S3 - Arduino
+0x82C2 | LILYGO T-Dongle-S3 - CircuitPython
+0x82C3 | LILYGO T-Dongle-S3 - UF2 Bootloader


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->
[LILYGO T-Dongle S3](https://lilygo.cc/products/t-dongle-s3)

It's a USB dongle containing an ESP32-S3, 0.96" LCD Display, and SD card slot.

PID is needed to add CircuitPython support.

I am not affiliated in anyway with LILYGO.