### PR TITLE
Generic Red ESP32-S2-WROOM with Type-C

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -713,3 +713,4 @@ PID    | Product name
 0x82C1 | LILYGO T-Dongle-S3 - Arduino
 0x82C2 | LILYGO T-Dongle-S3 - CircuitPython
 0x82C3 | LILYGO T-Dongle-S3 - UF2 Bootloader
+0x82C4 | Generic Red ESP32-S2-WROOM - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -713,4 +713,4 @@ PID    | Product name
 0x82C1 | LILYGO T-Dongle-S3 - Arduino
 0x82C2 | LILYGO T-Dongle-S3 - CircuitPython
 0x82C3 | LILYGO T-Dongle-S3 - UF2 Bootloader
-0x82C4 | Generic Red ESP32-S2-WROOM - CircuitPython
+0x82C4 | Generic Red ESP32-S2-WROOM with Type-C - CircuitPython


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->
### Device
An unbranded, red development/breakout board sold on AliExpress (such as [L1](https://vi.aliexpress.com/item/1005006307343006.html), [L2](https://vi.aliexpress.com/item/1005008212569068.html), [L3](https://vi.aliexpress.com/item/1005007477549296.html)) that has a USB Type-C port.

### Chip
ESP32-S2-WROOM

### Reasoning
For [this pull request](https://github.com/adafruit/circuitpython/pull/10060) to add this board to CircuitPython.