### PR TITLE
Added Heltec Vision Master 290

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -714,3 +714,7 @@ PID    | Product name
 0x82C2 | LILYGO T-Dongle-S3 - CircuitPython
 0x82C3 | LILYGO T-Dongle-S3 - UF2 Bootloader
 0x82C4 | Generic Red ESP32-S2-WROOM with Type-C - CircuitPython
+0x82C5 | Heltec Vision Master E290 - UF2 Bootloader
+0x82C6 | Heltec Vision Master E290 - CircuitPython
+0x82C7 | Heltec Vision Master E290 - Arduino
+


### PR DESCRIPTION
Heltec Vision Master e290 LoRa Epaper device.
ESP32-S3.
Requesting as a developer unassociated with Adafruit and Heltec for use developing CircuitPython support for this dev board.