### PR TITLE
Allocate PID for LineLIGHT Fusion Smart by WERMA Signaltechnik GmbH + Co. KG 

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -722,3 +722,4 @@ PID    | Product name
 0x82CA | Heltec Vision Master E290 - Arduino
 0x82CB | METADOX Soundproof Mask Headset USB - ESP32-S3
 0x82CC | EVO X1E
+0x82CD | WERMA Signaltechnik GmbH + Co. KG - LineLIGHT Fusion Smart


### PR DESCRIPTION
Hello,

I would like to allocate a new PID for our product.

- A short description of what the device is going to do (e.g. cat tracker with USB trace download)
Industial Signal Device

- What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
ESP32-S2

- Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
The PID is used for our PC-Software to detect the product 

- If you're requesting a PID on behalf of a company, please mention the name of the company
WERMA Signaltechnik GmbH + Co.  KG

- If applicable/available, a website or other URL with information about your product or company
https://www.werma.com/

Thank you!