### PR TITLE
add Waveshare ESP32S2 Touch LCD 2 for tinyuf2 and Circuitpython

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -723,3 +723,5 @@ PID    | Product name
 0x82CB | METADOX Soundproof Mask Headset USB - ESP32-S3
 0x82CC | EVO X1E
 0x82CD | WERMA Signaltechnik GmbH + Co. KG - LineLIGHT Fusion Smart
+0x82CE | Waveshare ESP32-S3-Touch-LCD-2 - CircuitPython
+0x82CF | Waveshare ESP32-S3-Touch-LCD-2 - UF2 Bootloader


### PR DESCRIPTION
The board is Waveshare part No ESP32-S3-Touch-LCD-2
_ESP32-S3 2inch Capacitive Touch Display Development Board_
https://www.waveshare.com/esp32-s3-touch-lcd-2.htm?sku=29667

I am not affiliated with Waveshare.
I noticed there are a few Waveshare LCD boards that were added, but this one was not in there.
PRs for Circuitpython and tinyUF2 are ready to go.
