### PR TITLE
Add SHED Access Control Core

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -725,3 +725,4 @@ PID    | Product name
 0x82CD | WERMA Signaltechnik GmbH + Co. KG - LineLIGHT Fusion Smart
 0x82CE | Waveshare ESP32-S3-Touch-LCD-2 - CircuitPython
 0x82CF | Waveshare ESP32-S3-Touch-LCD-2 - UF2 Bootloader
+0x82D0 | SHED Makerspace Access Control Core (ESP32 S2)


### PR DESCRIPTION
Hello,

I'm looking to get a custom PID for an open-source project our makerspace is developing. It is an Access Control System, allowing us to limit access to equipment based on trainings, and monitor who is using the equipment. 

The system is built around an ESP32-S2, we're specifically using the ESP32-S2-MINI-2-N4 module on our board. 

The custom PID will be used so that a configuration program we are writing (for setting system settings via USB) can detect the device and automatically connect to it. 

This is being developed by the Rochester Institute of Technology SHED Makerspace. More info at; https://github.com/rit-construct-makerspace/access-control-hardware/wiki (mostly pertaining to the last revision of the hardware, but same operating concept). 

If this PID is taken by another request we're fine with any other one. 

Thank you!

-Jim