### PR TITLE
Add Elecrow ThinkNode M2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -734,3 +734,6 @@ PID    | Product name
 0x82D6 | LILYGO T-LoRa-Pager - UF2 Bootloader
 0x82D7 | Glydr Galactic Holdings Inc - Glydr™
 0x82D8 | DanioVision Observation Chamber - Noldus Information Technology BV
+0x82D9 | Elecrow ThinkNode M2 - Arduino
+0x82DA | Elecrow ThinkNode M2 - CircuitPython/Micropython
+0x82DB | Elecrow ThinkNode M2 - UF2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. ThinkNode M2 LoRa Signal Transceiver with 1.3” OLED Display
2. ESPRESSIF ESP32-S3
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. https://www.elecrow.com/thinknode-m2-meshtastic-lora-signal-transceiver-powered-by-esp32-s3-with-1-3-oled-display.html

Please, let me know if you require any additional information!
