### PR TITLE
Added Unexpected Maker EDGES3 and SQUiXL

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -737,3 +737,9 @@ PID    | Product name
 0x82D9 | Elecrow ThinkNode M2 - Arduino
 0x82DA | Elecrow ThinkNode M2 - CircuitPython/Micropython
 0x82DB | Elecrow ThinkNode M2 - UF2 Bootloader
+0x82DC | Unexpected Maker EDGES3 - Arduino
+0x82DD | Unexpected Maker EDGES3 - CircuitPython/MicroPython
+0x82DE | Unexpected Maker EDGES3 - UF2 Bootloader
+0x82DF | Unexpected Maker SQUiXL - Arduino
+0x82E0 | Unexpected Maker SQUiXL - CircuitPython/MicroPython
+0x82E1 | Unexpected Maker SQUiXL - UF2 Bootloader


### PR DESCRIPTION
I'm requesting 3x PIDs for my new EDGES3 Board and 3x PIDs for my new product - SQUiXL.

One each for CircuitPython/MicroPython, Arduino and the UF2 Bootloader

EDGES3 is my new ESP32-S3 based, fully featured module that uses an m.2 connector for reusability on carrier boards.
My product page is it not public yet, but here's a picture of an unpopulated board, because I'm at home and don't have pics of a populated prototype here.
 
![edges3](https://github.com/user-attachments/assets/ba39c742-8bd1-491f-8e9f-162e3ac7d58c)


SQUiXL is an ESP32-S3 based portable touch screen device that packs in a huge amount of peripherals, including I2S amp + speaker, haptics, low power RTC, battery + FG, uSD card slot, magnetic charge/USB and of course the beautiful 480x480 tricolor screen :)

Again, the product page is not public yet, but here's a photo of SQUiXL with a bunch of case colors.
![IMG_2472](https://github.com/user-attachments/assets/8205387b-83b7-4aa0-bf1c-a28b9b537600)

Reason for custom PIDs are:

CircuitPython - Adafruit require every board that runs CircuitPython to have a unique PID for CircuitPython and the UF2 Bootloader

Arduino - Having a unique PID allows the board to be listed against the port it's on in the ports dropdown list, so once flashed in the Arduino IDE for the first time, my board will show up with their correct names, instead of "generic ESP32 dev board" :)

I am requesting these PIDs on behalf of my Company, Unexpected Maker

Thanks :)