### PR TITLE
0x82E3 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -744,3 +744,4 @@ PID    | Product name
 0x82E0 | Unexpected Maker SQUiXL - CircuitPython/MicroPython
 0x82E1 | Unexpected Maker SQUiXL - UF2 Bootloader
 0x82E2 | Dilon Tech Probe (ESP32 S3)
+0x82E3 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader


### PR DESCRIPTION
Added:
0x82E3 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader


<!-- Please answer the questions in the README.md of this repo: 
- It is a educational board with 3 sensors and SD Card reader
- ESP32-S2FH4
- It is for a UF2 Boorloader
- Domino4, no link yet
-->