### PR TITLE
Updated allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -639,7 +639,7 @@ PID    | Product name
 0x8277 | Waveshare ESP32-S3-Touch-AMOLED-1.43 - UF2 Bootloader
 0x8278 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - CircuitPython/MicroPython
 0x8279 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - UF2 Bootloader
-0x827A | Unallocated
+0x827A | kenny's Labs - WaKu Controller
 0x827B | Unallocated
 0x827C | Waveshare ESP32-S3-GEEK - Arduino
 0x827D | Waveshare ESP32-S3-GEEK - UF2 Bootloader


### PR DESCRIPTION
- The device in question is a custom built board for PC water-cooling and RGB control.
- Chip in question is a ESP32-S3
- Custom PID is needed for my software running on the host computer to pipe the data to HWiNFO64 and easily identify the device that way.
- Currently there is no company, I'm a sole developer but soon will launch a small product website and a public repository since it will be an open source hardware design.

