### PR TITLE
Add FED4 

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -746,3 +746,6 @@ PID    | Product name
 0x82E2 | Dilon Tech Probe (ESP32 S3)
 0x82E3 | Work Louder - Knob v1 - ISO
 0x82E4 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader
+0x82E5 | FED4 ESP32-S3 - Arduino
+0x82E6 | FED4 ESP32-S3 - CircuitPython
+0x82E7 | FED4 ESP32-S3 - Uf2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -746,6 +746,6 @@ PID    | Product name
 0x82E2 | Dilon Tech Probe (ESP32 S3)
 0x82E3 | Work Louder - Knob v1 - ISO
 0x82E4 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader
-0x82E5 | FED4 ESP32-S3 - Arduino
-0x82E6 | FED4 ESP32-S3 - CircuitPython
-0x82E7 | FED4 ESP32-S3 - Uf2 Bootloader
+0x82E5 | FED4 - Arduino
+0x82E6 | FED4 - CircuitPython
+0x82E7 | FED4 - Uf2 Bootloader


### PR DESCRIPTION
- The **FED4** is small commercial product used by university labs to track the feeding behaviors of mince. 

![FED4](https://github.com/user-attachments/assets/1e96e09b-535d-4d47-850b-cf4769f5c745)
![image001](https://github.com/user-attachments/assets/66b60a03-9074-41f8-ae2c-8b8206d908ec)

- Its using the **ESP32-S3**

- Need for custom PIDs for **CircuitPython** - Adafruit require every board that runs **CircuitPython** to have a unique PID for CircuitPython and the UF2 Bootloader and **Arduino** - Having a unique PID allows the board to be listed in **Arduino** IDE

- Registering on behalf of my company Smart Bee Designs LLC (designer of the FED4)