### PR TITLE
Add Wireless-tag WT99P4C5

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -746,3 +746,6 @@ PID    | Product name
 0x82E2 | Dilon Tech Probe (ESP32 S3)
 0x82E3 | Work Louder - Knob v1 - ISO
 0x82E4 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader
+0x82E8 | Wireless-tag WT99P4C5 - Arduino
+0x82E9 | Wireless-tag WT99P4C5 - CircuitPython
+0x82EA | Wireless-tag WT99P4C5 - Uf2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. Wireless-tag WT99P4C5 board
2. ESPRESSIF ESP32-P4
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. https://github.com/wireless-tag-com/DevBoard/tree/WT99P4C5-S1

PIDs are requested to follow previous PR #243 
Unfortunately this [**breaks logic of CI Actions build**](https://github.com/espressif/usb-pids/actions/runs/15940988965)

Please, let me know if you require any additional information!