### PR TITLE
Add Waveshare ESP32-S3-Touch-AMOLED-1.75

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -658,9 +658,9 @@ PID    | Product name
 0x828A | Waveshare ESP32-S3-LCD-1.47 - Arduino
 0x828B | Waveshare ESP32-S3-LCD-1.47 - CircuitPython/MicroPython
 0x828C | Waveshare ESP32-S3-LCD-1.47 - UF2 Bootloader
-0x828D | Unallocated
-0x828E | Unallocated
-0x828F | Unallocated
+0x828D | Waveshare ESP32-S3-Touch-AMOLED-1.75 - Arduino
+0x828E | Waveshare ESP32-S3-Touch-AMOLED-1.75 - CircuitPython/MicroPython
+0x828F | Waveshare ESP32-S3-Touch-AMOLED-1.75 - UF2 Bootloader
 0x8290 | Waveshare ESP32-S3-Touch-LCD-1.85 - Arduino
 0x8291 | Waveshare ESP32-S3-Touch-LCD-1.85 - CircuitPython/MicroPython
 0x8292 | Waveshare ESP32-S3-Touch-LCD-1.85 - UF2 Bootloader


### PR DESCRIPTION
HI Spritetm,

I have completely rework the changes into a new commit.  Let's try this new pull request again.
Thank you!  

Add Waveshare ESP32-S3-Touch-AMOLED-1.75:
Product link: https://www.waveshare.com/product/esp32-s3-touch-amoled-1.75.htm?sku=31262
Allocate PIDs for Arduino, CircuitPython/MicroPython, and UF2 Bootloader.

0x828D | Waveshare ESP32-S3-Touch-AMOLED-1.75 - Arduino
0x828E | Waveshare ESP32-S3-Touch-AMOLED-1.75 - CircuitPython/MicroPython
0x828F | Waveshare ESP32-S3-Touch-AMOLED-1.75 - UF2 Bootloader