### PR TITLE
Added a PID for Sentient Computing

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -755,3 +755,4 @@ PID    | Product name
 0x82EB | Deneyap Kart v2 - Arduino
 0x82EC | Deneyap Kart v2 - CircuitPython
 0x82ED | Deneyap Kart v2 - UF2 Bootloader
+0x82EE | Sentient Computing - Tyr


### PR DESCRIPTION
**Description:** We are primarily a software company. However, on occasion clients do require boutique hardware solutions. When working with these we quite often interact with industry/proprietary hardware and cannot guarantee the hardware that will be used along side it. Since we currently use `ESP32-S3` in situations like these having a dedicated `PID` ensures reliable enumeration and prevents driver or PID conflicts across deployments.

**Chip:** `ESP32-S3`

**Why:** Because when delivering to a client we can't risk a already populated `PID` interfering with our software solutions.

**Company:** [Sentient Computing (https://sencom.com.au/)](https://sencom.com.au/)