### PR TITLE
Added Laptitude PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -758,5 +758,3 @@ PID    | Product name
 0x82EE | Sentient Computing - Tyr
 0x82EF | Laptitude™ - Bootloader
 0x82F0 | Laptitude™ - Main
-0x82F1 | Laptitude™ - Reserved 1
-0x82F2 | Laptitude™ - Reserved 2


### PR DESCRIPTION
Laptitude is a training system for laparoscopic surgery. You can find more information on the product website: [https://grendelmedical.com/laptitude/](). Note that this is a training tool and not used during medical procedures, and thus is not a medical device.

It uses the ESP32-S3 chip. We are using tinyusb for both CDC and HID endpoints, but for the HID endpoint we'd like a custom PID to automatically identify the device on the desktop training application. We also would like a separate PID to identify the device in bootloader mode, and reserve two extra to keep major product revisions sequential. 

Let me know if you have any questions.