### PR TITLE
Added PID for WERMA MC55 Smart Signal Beacon

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -758,3 +758,4 @@ PID    | Product name
 0x82EE | Sentient Computing - Tyr
 0x82EF | Laptitude™ - Bootloader
 0x82F0 | Laptitude™ - Main
+0x82F1 | WERMA Signaltechnik GmbH + Co. KG - MC55 Smart


### PR DESCRIPTION
Hello,

I would like to allocate a new PID for our product.

A short description of what the device is going to do (e.g. cat tracker with USB trace download) Industial Signal Device

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2) ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs) The PID is used for our PC-Software to detect the product

If you're requesting a PID on behalf of a company, please mention the name of the company WERMA Signaltechnik GmbH + Co. KG

If applicable/available, a website or other URL with information about your product or company https://www.werma.com/

Thank you!


<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->