### PR TITLE
add PIDs for CharaChorder Forge Trackball

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -759,3 +759,5 @@ PID    | Product name
 0x82EF | Laptitude™ - Bootloader
 0x82F0 | Laptitude™ - Main
 0x82F1 | WERMA Signaltechnik GmbH + Co. KG - MC55 Smart
+0x82F2 | CharaChorder Forge Trackball S2
+0x82F3 | CharaChorder Forge Trackball S2 - UF2 Bootloader


### PR DESCRIPTION
CharaChorder Forge Trackball S2 is a USB trackball that can also integrate with chording enabled Forge keyboards.
ESP32-S2FH4
The device pairs with serial applications that need PIDs for filtering valid devices
CharaChorder, LLC
The product is currently bundled with this product:
https://forgekeyboard.com/products/master-forge-premium