### PR TITLE
Add PIDs for FoBE Quill ESP32-S3 Mesh

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -761,3 +761,6 @@ PID    | Product name
 0x82F1 | WERMA Signaltechnik GmbH + Co. KG - MC55 Smart
 0x82F2 | CharaChorder Forge Trackball S2
 0x82F3 | CharaChorder Forge Trackball S2 - UF2 Bootloader
+0x82F4 | FoBE Quill ESP32-S3 Mesh - Arduino
+0x82F5 | FoBE Quill ESP32-S3 Mesh - CircuitPython/MicroPython
+0x82F6 | FoBE Quill ESP32-S3 Mesh - UF2 Bootloader


### PR DESCRIPTION
Hi, @Spritetm 

It's new ESP32-S3 Dev Board FoBE Quill ESP32-S3 Mesh
Chip: ESP32-S3
Product link: [https://docs.fobestudio.com/product/f1102](https://docs.fobestudio.com/product/f1102)
Vendor: FoBE Studio
<img width="668" height="496" alt="image" src="https://github.com/user-attachments/assets/4585de5d-ad3c-42f4-a754-6a076c314aa5" />


0x82F4 | FoBE Quill ESP32-S3 Mesh - Arduino
0x82F5 | FoBE Quill ESP32-S3 Mesh - CircuitPython/MicroPython
0x82F6 | FoBE Quill ESP32-S3 Mesh - UF2 Bootloader

Thank you!