### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -764,3 +764,5 @@ PID    | Product name
 0x82F4 | FoBE Quill ESP32-S3 Mesh - Arduino
 0x82F5 | FoBE Quill ESP32-S3 Mesh - CircuitPython/MicroPython
 0x82F6 | FoBE Quill ESP32-S3 Mesh - UF2 Bootloader
+0x82F7 | Namaka Reverb - Silver Series - VTR Effects
+0x82F8 | Ignis Amp Modeler - Diamond Series - VTR Effects 


### PR DESCRIPTION
0x82F7 | Namaka Reverb:

- ESP32-S3
- We need a custom PID because this is a commercial device that connects to an application and receives updates.
- vtreffects.com

0x82F8 | Ignis Amp Modeler:

- ESP32-S3
- We need a custom PID because this is a commercial device that connects to an application and receives updates.
- vtreffects.com