### PR TITLE
Add Elecrow ThinkNode M5

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -766,3 +766,6 @@ PID    | Product name
 0x82F6 | FoBE Quill ESP32-S3 Mesh - UF2 Bootloader
 0x82F7 | Namaka Reverb - Silver Series - VTR Effects
 0x82F8 | Ignis Amp Modeler - Diamond Series - VTR Effects 
+0x82F9 | Elecrow ThinkNode M5 - Arduino
+0x82FA | Elecrow ThinkNode M5 - CircuitPython/Micropython
+0x82FB | Elecrow ThinkNode M5 - UF2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,
thank you so much for this great service!
Please, process the pull request, when able.

1. ThinkNode M5 LoRa Signal Transceiver with 1.54" e-Paper display
2. ESPRESSIF ESP32-S3
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. https://www.elecrow.com/thinknode-m5-meshtastic-lora-signal-transceiver-esp32-s3-1-54-screen-gps-function.html

Please, let me know if you require any additional information!