### PR TITLE
Kskelm patch 1

### DIFF
--- a/enigma.json
+++ b/enigma.json
@@ -1,0 +1,7 @@
+{
+  "pid": "auto",
+  "description": "escape room control panel elements",
+  "vendor": "MadGoat Labs",
+  "url": "https://github.com/kskelm/esp32-usb-pids",
+  "notes": "puzzle room i/o, esp32-s3"
+}

--- a/enigma.json
+++ b/enigma.json
@@ -1,7 +1,7 @@
 {
   "pid": "auto",
-  "description": "escape room control panel elements",
+  "description": "enigma control device family",
   "vendor": "MadGoat Labs",
-  "url": "https://github.com/kskelm/esp32-usb-pids",
-  "notes": "puzzle room i/o, esp32-s3"
+  "url": "https://github.com/kskelm/enigma",
+  "notes": "set of 8 usb hid+msc control devices (controls, lighting, displays, etc.) built on esp32-s3"
 }


### PR DESCRIPTION
Description:
USB-based I/O modules for Windows/macOS/Linux that provide switch, encoder, and analog inputs as well as RGB LED, small display, and relay/servo outputs. Designed for interactive control panels, simulation rigs, and escape room puzzles.

Chip used:
ESP32-S3

Why a custom PID is needed:
All modules enumerate as HID+MSC devices with a shared USB protocol. A unique PID ensures consistent identification across host systems and avoids conflicts with other Espressif-based devices.

Company / website:
MadGoat Labs — https://madgoatlabs.com (site not yet active)