### PR TITLE
Added new Soldered boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -769,3 +769,6 @@ PID    | Product name
 0x82F9 | Elecrow ThinkNode M5 - Arduino
 0x82FA | Elecrow ThinkNode M5 - CircuitPython/Micropython
 0x82FB | Elecrow ThinkNode M5 - UF2 Bootloader
+0x82FC | Soldered NULA Mini ESP32-C6
+0x82FD | Soldered NULA DeepSleep ESP32-S3
+0x82FE | Soldered NULA Vision ESP32-S3


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->

Greetings,

we are adding several new Soldered development boards so we can use the PID in the Arduino and Micropython cores - for the best experience of our users.  

NULA Mini is ESP32-C6 based, small footprint, portable, for wearables.
NULA DeepSleep is ESP32-S3 based - for ultra low-power projects, standard pinout
NULA Vision is ESP32-S3 based - with a built in camera and microphone

Visit our company's site at [soldered.com](https://soldered.com/) - the products are yet to be published. Let me know if I can help further

Best
-Rob
