### PR TITLE
Added PID for Vulintus RePlay IMU.

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -769,3 +769,6 @@ PID    | Product name
 0x82F9 | Elecrow ThinkNode M5 - Arduino
 0x82FA | Elecrow ThinkNode M5 - CircuitPython/Micropython
 0x82FB | Elecrow ThinkNode M5 - UF2 Bootloader
+0x82FC | Soldered NULA DeepSleep ESP32-S3
+0x82FD | Soldered NULA Vision ESP32-S3
+0x82FE | Vulintus RePlay IMU


### PR DESCRIPTION
Includes PIDs from pending pull request for commit "rsoric:main".

Vulintus creates custom research equipment used in clinical biomedical research. The ESP32-S3 used in our RePlay IMU device coordinates multiple position and movement sensors to measure hand and arm movements during physical rehabilitation. We need a custom PID so that the device is automatically discoverable on systems that might have other ESP32-based devices connected.

www.vulintus.com