### PR TITLE
Add Digimet WIC5 Control to allocated PIDs list

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -772,3 +772,4 @@ PID    | Product name
 0x82FC | Soldered NULA DeepSleep ESP32-S3
 0x82FD | Soldered NULA Vision ESP32-S3
 0x82FE | Vulintus RePlay IMU
+0x82FF | Digimet WIC5 Control


### PR DESCRIPTION
The device will control LEDs and read sensors to help capture better images.
The chip is ESP32-S3.
I need a custom PID for the user to have better understanding of the device functionality and to filter the devices by PID for automatic connection.
Our website is https://www.digimet.solutions/ - this product is going to be published soon.
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->