### PR TITLE
Added PIDs for M5STACK DinMeter

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -783,3 +783,6 @@ PID    | Product name
 0x8307 | SEIKAN Sound Voltex Controller
 0x8308 | SEIKAN Fate Grand/Order Controller
 0x8309 | SEIKAN VR Tracker
+0x830A | M5STACK DinMeter - Arduino
+0x830B | M5STACK DinMeter - Micropython/CircuitPython
+0x830C | M5STACK DinMeter - UF2 Bootloader


### PR DESCRIPTION
- Give a short description of the device and its function, 
A development board with a display and a rotary knob in a DIN form factor

- Tell us what chip you're using, 
ESP32-S3FN8

- Mention why you need a custom PID
TinyUF2 and Micropython/CircuitPython require unique PIDs for any new boards added. I'm also adding an Arduino PID.

- If applicable/available mention your company and a link to the website of the product.
https://docs.m5stack.com/en/core/M5DinMeter
