### PR TITLE
Added Siemens Einbauleuchte 8WD56 

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -865,3 +865,4 @@ PID    | Product name
 0x8359 | Bilbos - Flow Meter Calibrator
 0x835A | F5 Datalink Adapter - Remote Camera Control
 0x835B | SynthHead - Midi Controller
+0x835C | Siemens - Einbauleuchte 8WD56 


### PR DESCRIPTION
A short description of what the device is going to do (e.g. cat tracker with USB trace download) -> Signaling Device 

What chip are you using for the device the PID is allocated for (e.g. ESP32-S2) -> ESP32-S2

Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs) -> Ensure communication with configuration software

If you're requesting a PID on behalf of a company, please mention the name of the company -> Siemens