### PR TITLE
Add new entry for Tensai BLE HID Dongle

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -866,3 +866,4 @@ PID    | Product name
 0x835A | F5 Datalink Adapter - Remote Camera Control
 0x835B | SynthHead - Midi Controller
 0x835C | Siemens - Einbauleuchte 8WD56 
+0x835D | Smart Solution For International Trade LLC - Tensai BLE HID Dongle


### PR DESCRIPTION
**Device description:** BLE-to-USB HID dongle for digital identity verification (mDL/document scanning). Connects to Windows, Linux, and macOS as a standard HID device via USB.

**Chip:** ESP32-S3

**Why a custom PID is needed:** The device uses a custom USB HID class for relaying BLE credential data to the host. The default TinyUSB HID PID causes identification conflicts with other generic ESP32 devices, and we need a unique PID for proper driver association across multiple OS platforms.

**Company:** Smart Solution For International Trade LLC (Muscat, Oman)

**Website:** https://smartsolutionint.com