### PR TITLE
Add PID 0x835E for CamSync Camera Sync Controller

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -867,3 +867,4 @@ PID    | Product name
 0x835B | SynthHead - Midi Controller
 0x835C | Siemens - Einbauleuchte 8WD56 
 0x835D | Smart Solution For International Trade LLC - Tensai BLE HID Dongle
+0x835E | CamSync - Camera Sync Controller


### PR DESCRIPTION
This is a controller for camera sync over USB. It is based on ESP32-S3.

The associated host software needs to uniquely identify the controller so it can be distinguished from other ESP32-S3 devices that use the default TinyUSB example PID.

No current web presence.