### PR TITLE
Add new allocated PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -870,3 +870,5 @@ PID    | Product name
 0x835E | CamSync - Camera Sync Controller
 0x835F | Barbiani Solucoes em Tecnologia LTDA
 0x8360 | Work Louder - Creator Micro v2 - Project 2077
+0x8361 | Gevto - Digital Scale Type A
+0x8362 | Gevto - Digital Scale Type B


### PR DESCRIPTION
Digital scale that connects to Android or Web App using USB CDC.

An ESP32-S3 is used.

Custom PID required to improve customer experience by filtering connect dialog (Web App) and allow auto-start of App on Android.

Currently no public web presence or company.