### PR TITLE
Add PID 0x8363 for PenEngineering S.R.L - AkiraConsole

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -872,3 +872,4 @@ PID    | Product name
 0x8360 | Work Louder - Creator Micro v2 - Project 2077
 0x8361 | Gevto - Digital Scale Type A
 0x8362 | Gevto - Digital Scale Type B
+0x8363 | PenEngineering S.R.L - AkiraConsole


### PR DESCRIPTION
## PID Request: 0x8363 — PenEngineering S.R.L - AkiraConsole

**Device description:**
AkiraConsole is a WebAssembly-based IoT device running AkiraOS (a Zephyr RTOS-based OS). 
It exposes a composite USB device: a CDC ACM virtual serial port (for Web Serial API access 
via lab.akiraos.dev) and a custom HID interface for user input.

**Chip:** ESP32-S3

**Why a custom PID is needed:**
AkiraOS uses a composite CDC ACM + HID configuration that requires host-side driver matching. 
The default TinyUSB PIDs do not cover this composite class combination, and a dedicated PID 
ensures correct enumeration across Windows, macOS, and Linux hosts without generic driver conflicts.

**Company:** PenEngineering S.R.L

**Website:** https://akiraos.dev