### PR TITLE
Add PIDs 0x8364, 0x8365 for Paige Braille - Paige Writer and Paige Connect

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -873,3 +873,5 @@ PID    | Product name
 0x8361 | Gevto - Digital Scale Type A
 0x8362 | Gevto - Digital Scale Type B
 0x8363 | PenEngineering S.R.L - AkiraConsole
+0x8364 | Paige Braille - Paige Writer
+0x8365 | Paige Braille - Paige Connect


### PR DESCRIPTION
**Device description:**

- **Paige Writer** — a writing device for the visually impaired, built on an ESP32-S3, exposing a USB interface to the host.
- **Paige Connect** — a companion connectivity device, also built on an ESP32-S3, exposing a USB interface to the host.

**Chip:** ESP32-S3 (both devices).

**Why a custom PID is needed:** Both products are commercial. We need each device to enumerate with a unique product identifier so our host-side software can reliably detect and target it on Windows, macOS, and Linux, without collisions against other ESP32-S3 devices using the default TinyUSB example PID, and to distinguish the two products from each other.

**Company:** Paige Braille

**Website:** https://www.paigebraille.com
