### PR TITLE
Add LilyGO T-Beam 1W

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -875,3 +875,6 @@ PID    | Product name
 0x8363 | PenEngineering S.R.L - AkiraConsole
 0x8364 | Paige Braille - Paige Writer
 0x8365 | Paige Braille - Paige Connect
+0x8367 | LilyGO T-Beam 1W - Arduino
+0x8368 | LilyGO T-Beam 1W - CircuitPython/MicroPython
+0x8369 | LilyGO T-Beam 1W - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -875,6 +875,6 @@ PID    | Product name
 0x8363 | PenEngineering S.R.L - AkiraConsole
 0x8364 | Paige Braille - Paige Writer
 0x8365 | Paige Braille - Paige Connect
-0x8367 | LilyGO T-Beam 1W - Arduino
-0x8368 | LilyGO T-Beam 1W - CircuitPython/MicroPython
-0x8369 | LilyGO T-Beam 1W - UF2 Bootloader
+0x8366 | LilyGO T-Beam 1W - Arduino
+0x8367 | LilyGO T-Beam 1W - CircuitPython/MicroPython
+0x8368 | LilyGO T-Beam 1W - UF2 Bootloader


### PR DESCRIPTION
     Hello Jeroen,

thank you so much for this great service!
Please, process the pull request, when able.

1. Development board with Semtech radio, FEM, GNSS, 128x64 OLED display and F550 battery holder
2. ESPRESSIF ESP32-S3-WROOM-1-N16R8
3. TinyUF2, Arduino and CircuitPython require unique PIDs for any new boards added
4. https://lilygo.cc/en-us/products/t-beam-1w

PIDs are selected to follow this ( early made ) PR https://github.com/espressif/usb-pids/pull/312

Please, let me know if you require any additional information!
