### PR TITLE
Add PIDs 0x8366-0x8375 for Starpoint Australis

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -881,13 +881,3 @@ PID    | Product name
 0x836D | Starpoint Australis - RC Focus
 0x836E | Starpoint Australis - Chameleon IQ
 0x836F | Starpoint Australis - Pavo Power
-0x8370 | Starpoint Australis - Reserved
-0x8371 | Starpoint Australis - Reserved
-0x8372 | Starpoint Australis - Reserved
-0x8373 | Starpoint Australis - Reserved
-0x8374 | Starpoint Australis - Reserved
-0x8375 | Starpoint Australis - Reserved
-0x8376 | Starpoint Australis - Reserved
-0x8377 | Starpoint Australis - Reserved
-0x8378 | Starpoint Australis - Reserved
-0x8379 | Starpoint Australis - Reserved

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -875,19 +875,19 @@ PID    | Product name
 0x8363 | PenEngineering S.R.L - AkiraConsole
 0x8364 | Paige Braille - Paige Writer
 0x8365 | Paige Braille - Paige Connect
-0x8366 | Starpoint Australis - SP3 Focus
-0x8367 | Starpoint Australis - Vela 7
-0x8368 | Starpoint Australis - Vela 9
-0x8369 | Starpoint Australis - RC Focus
-0x836A | Starpoint Australis - Chameleon IQ
-0x836B | Starpoint Australis - Pavo Power
-0x836C | Starpoint Australis - Reserved
-0x836D | Starpoint Australis - Reserved
-0x836E | Starpoint Australis - Reserved
-0x836F | Starpoint Australis - Reserved
+0x836A | Starpoint Australis - SP3 Focus
+0x836B | Starpoint Australis - Vela 7
+0x836C | Starpoint Australis - Vela 9
+0x836D | Starpoint Australis - RC Focus
+0x836E | Starpoint Australis - Chameleon IQ
+0x836F | Starpoint Australis - Pavo Power
 0x8370 | Starpoint Australis - Reserved
 0x8371 | Starpoint Australis - Reserved
 0x8372 | Starpoint Australis - Reserved
 0x8373 | Starpoint Australis - Reserved
 0x8374 | Starpoint Australis - Reserved
 0x8375 | Starpoint Australis - Reserved
+0x8376 | Starpoint Australis - Reserved
+0x8377 | Starpoint Australis - Reserved
+0x8378 | Starpoint Australis - Reserved
+0x8379 | Starpoint Australis - Reserved

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -875,3 +875,19 @@ PID    | Product name
 0x8363 | PenEngineering S.R.L - AkiraConsole
 0x8364 | Paige Braille - Paige Writer
 0x8365 | Paige Braille - Paige Connect
+0x8366 | Starpoint Australis - SP3 Focus
+0x8367 | Starpoint Australis - Vela 7
+0x8368 | Starpoint Australis - Vela 9
+0x8369 | Starpoint Australis - RC Focus
+0x836A | Starpoint Australis - Chameleon IQ
+0x836B | Starpoint Australis - Pavo Power
+0x836C | Starpoint Australis - Reserved
+0x836D | Starpoint Australis - Reserved
+0x836E | Starpoint Australis - Reserved
+0x836F | Starpoint Australis - Reserved
+0x8370 | Starpoint Australis - Reserved
+0x8371 | Starpoint Australis - Reserved
+0x8372 | Starpoint Australis - Reserved
+0x8373 | Starpoint Australis - Reserved
+0x8374 | Starpoint Australis - Reserved
+0x8375 | Starpoint Australis - Reserved


### PR DESCRIPTION
Add PIDs 0x8366-0x8375 for Starpoint Australis astronomy products that utilise ESP32 S3 series of controllers on custom PCB boards.

- Device description: A range of astronomy accessory controllers including telescope focusers, power controllers, and imaging accessories. Each product uses a custom PCB with USB CDC and/or MSC interfaces for PC control and data logging.

  - SP3 Focus (0x8366): USB/BT/WiFi telescope focuser controller with CDC serial control and MSC data logging
  - Vela 7 (0x8367): USB/BT/WiFi 7-channel astronomy accessory controller and MSC data logging
  - Vela 9 (0x8368): USB/BT/WiFi 9-channel astronomy accessory controller and MSC data logging
  - RC Focus (0x8369): USB/BT/WiFi telescope focuser controller with CDC serial control and MSC data logging
  - Chameleon IQ (0x836A): Environmental and control hub for telescopes
  - Pavo Power (0x836B): USB power distribution controller for astronomy equipment
  - 0x836C-0x8375: Reserved for future Starpoint Australis products (additional focusers and variations of the above)

- Chip: ESP32-S3

- Reason for custom PID: To correctly identify each distinct Starpoint Australis product during USB enumeration with proper manufacturer and product descriptor strings, avoiding conflict with the ESP32-S3 ROM default PID 0x1001.

- Company: Starpoint Australis
- Website: https://www.starpointaustralis.com.au