### PR TITLE
Add PID 0x8369 for https://github.com/geeksville/touchy-pad

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -878,3 +878,4 @@ PID    | Product name
 0x8366 | LilyGO T-Beam 1W - Arduino
 0x8367 | LilyGO T-Beam 1W - CircuitPython/MicroPython
 0x8368 | LilyGO T-Beam 1W - UF2 Bootloader
+0x8369 | Geeksville - Touchy-pad


### PR DESCRIPTION
Per README.md:
* Purpose: touchy-pad is a GPL licensed 'premium' trackpad with reconfigurable buttons/screen
* Chip: Various cheap ESP32 based boards are supported but mostly ESP32-S3
* I need a custom PID we run custom protocol buffer based endpoints that our sister python app needs to find dynamically.
* No company involved, will be a public open source project, currently under my personal geeksville acct
* Website https://github.com/geeksville/touchy-pad


<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->