### PR TITLE
add Waveshare ESP32-S3-Tiny-N8R8

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -893,3 +893,6 @@ PID    | Product name
 0x8375 | PCBCupid Glyph S3 with PSRAM - Arduino
 0x8376 | PCBCupid Glyph S3 with PSRAM - CircuitPython/MicroPython
 0x8377 | PCBCupid Glyph S3 with PSRAM - UF2 Bootloader
+0x8378 | Waveshare ESP32-S3-Tiny-N8R8 - Arduino
+0x8379 | Waveshare ESP32-S3-Tiny-N8R8 - CircuitPython/MicroPython
+0x837A | Waveshare ESP32-S3-Tiny-N8R8 - UF2 Bootloader


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->

**Waveshare ESP32-S3-Tiny-N8R8**: ESP32-S3 Mini Development Board, Based on ESP32-S3-PICO-1-N8R8.  
https://www.waveshare.com/esp32-s3-tiny.htm?sku=339  

PIDs are added to be used in Arduino, tinyuf2 and CircuitPython.  

Related PRs (waiting for PID allocation):
* https://github.com/adafruit/circuitpython/pull/11033
* https://github.com/adafruit/tinyuf2/pull/475