### PR TITLE
Add new entries for PCBCupid Glyph S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -887,3 +887,9 @@ PID    | Product name
 0x836F | Starpoint Australis - Pavo Power
 0x8370 | Work Louder - Nomad [E] v2 - ISO
 0x8371 | Work Louder - Nomad [E] v2 - ANSI
+0x8372 | PCBCupid Glyph S3 - Arduino
+0x8373 | PCBCupid Glyph S3 - CircuitPython/MicroPython
+0x8374 | PCBCupid Glyph S3 - UF2 Bootloader
+0x8375 | PCBCupid Glyph S3 with PSRAM - Arduino
+0x8376 | PCBCupid Glyph S3 with PSRAM - CircuitPython/MicroPython
+0x8377 | PCBCupid Glyph S3 with PSRAM - UF2 Bootloader


### PR DESCRIPTION
- A custom development board based on esp32s3 with inbuilt battery management system (BMS).  
- ESP32S3 mini N8 & ESP32S3 mini N4R2
- To have a custom 
- product link : https://shop.pcbcupid.com/product/gd004


Note - This is a follow up PR for #317 