### PR TITLE
Sterling Hawk - USB 2.4GHz Receiver

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -471,3 +471,4 @@ PID    | Product name
 0x81CF | Columbia DSL Sensor Board - Arduino
 0x81D0 | Columbia DSL Sensor Board - CircuitPython
 0x81D1 | Columbia DSL Sensor Board - UF2 Bootloader
+0x81D2 | Sterling Hawk - SterlingKey

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -896,3 +896,4 @@ PID    | Product name
 0x8378 | Waveshare ESP32-S3-Tiny-N8R8 - Arduino
 0x8379 | Waveshare ESP32-S3-Tiny-N8R8 - CircuitPython/MicroPython
 0x837A | Waveshare ESP32-S3-Tiny-N8R8 - UF2 Bootloader
+0x837B | Sterling Hawk - USB 2.4GHz Receiver


### PR DESCRIPTION
This is a device that communicates via ESP-NOW with one of my previous entries (0x81D2 | Sterling Hawk - SterlingKey). It is being used as an alternative communiation method to bluetooth. It receives data from esp-now and uses TinyUSB to convert them to USB HID data.

I'm using the ESP32-S3 Mini.

The custom PID will make it easier to connect to my WebHID interface that I will build for debugging and for updating the firmware.

Link to the device
https://sterlinghawk.com/shop/products/electronics/usb-2-4ghz-receiver/

Thank you!