### PR TITLE
Allocate 0x837C-0x837D for TEILE Elektronik MIB GmbH DSP

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -897,3 +897,5 @@ PID    | Product name
 0x8379 | Waveshare ESP32-S3-Tiny-N8R8 - CircuitPython/MicroPython
 0x837A | Waveshare ESP32-S3-Tiny-N8R8 - UF2 Bootloader
 0x837B | Sterling Hawk - USB 2.4GHz Receiver
+0x837C | TEILE Elektronik MIB GmbH - DSP - UAC2.0 Audio + Custom DFU/RPC
+0x837D | TEILE Elektronik MIB GmbH - DSP - Vendor Specific Interface (alternative mode)


### PR DESCRIPTION
### Device description
A digital signal processor (DSP) audio product. It exposes two USB personalities selected by its boot mode, and the host recognizes which mode is active by the PID:

- **0x837C** — UAC2.0 audio (composite) plus a custom DFU/RPC interface for firmware update and control.
- **0x837D** — vendor-specific remote-control interface (alternative boot mode).

### Chip
ESP32-P4 (using its native USB interface).

### Why a custom PID is needed
The vendor-specific remote-control protocol uses a non-standard host driver rather than the default TinyUSB class drivers, so the pre-allocated TinyUSB PIDs don't apply. Two PIDs are required because the product has two distinct boot modes presenting different USB descriptors, and the host distinguishes them by PID.

### Company
TEILE Elektronik MIB GmbH. This is a proprietary product.