### PR TITLE
Add MeXkey3 entries to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -899,5 +899,5 @@ PID    | Product name
 0x837B | Sterling Hawk - USB 2.4GHz Receiver
 0x837C | TEILE Elektronik MIB GmbH - DSP - UAC2.0 Audio + Custom DFU/RPC
 0x837D | TEILE Elektronik MIB GmbH - DSP - Vendor Specific Interface (alternative mode)
-0x837e | MeXkey3
-0x837f | MeXkey3 (recovery mode)
+0x837E | MeXkey3
+0x837F | MeXkey3 (recovery mode)

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -899,3 +899,5 @@ PID    | Product name
 0x837B | Sterling Hawk - USB 2.4GHz Receiver
 0x837C | TEILE Elektronik MIB GmbH - DSP - UAC2.0 Audio + Custom DFU/RPC
 0x837D | TEILE Elektronik MIB GmbH - DSP - Vendor Specific Interface (alternative mode)
+0x0030 | MeXkey3
+0x0032 | MeXkey3 (recovery mode)

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -899,5 +899,5 @@ PID    | Product name
 0x837B | Sterling Hawk - USB 2.4GHz Receiver
 0x837C | TEILE Elektronik MIB GmbH - DSP - UAC2.0 Audio + Custom DFU/RPC
 0x837D | TEILE Elektronik MIB GmbH - DSP - Vendor Specific Interface (alternative mode)
-0x0030 | MeXkey3
-0x0032 | MeXkey3 (recovery mode)
+0x837e | MeXkey3
+0x837f | MeXkey3 (recovery mode)


### PR DESCRIPTION
MeXkey3 – a hardware password and key manager using a composite USB device.

Chip used:

ESP32-P4

Why a custom PID is needed:

The device implements a composite USB device (e.g., keyboard + CCID or custom HID), and the default TinyUSB PIDs do not provide the necessary class/vendor combination for proper operation and identification. A dedicated PID is required to avoid conflicts and ensure correct driver binding.

Company name (if requesting on behalf of a company):

觅叉电子商务（无锡）有限公司

(Mi Cha E-commerce (Wuxi) Co., Ltd.)

Website or additional URL:

https://mexdiy.com/