### PR TITLE
Allocate 0x8380-0x8385 for Eliobot (S2 & S3)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -901,3 +901,9 @@ PID    | Product name
 0x837D | TEILE Elektronik MIB GmbH - DSP - Vendor Specific Interface (alternative mode)
 0x837E | MeXkey3
 0x837F | MeXkey3 (recovery mode)
+0x8380 | Eliobot-S2 - Arduino
+0x8381 | Eliobot-S2 - CircuitPython
+0x8382 | Eliobot-S2 - UF2 Bootloader
+0x8383 | Eliobot-S3 - Arduino
+0x8384 | Eliobot-S3 - CircuitPython
+0x8385 | Eliobot-S3 - UF2 Bootloader


### PR DESCRIPTION
## Device description

Eliobot is an educational robot designed for learning programming and robotics. 
It is available in two hardware versions:

- **Eliobot-S2** (ESP32-S2): the original version
- **Eliobot-S3** (ESP32-S3): the current version

Both boards support **CircuitPython** and **Arduino** (via a dedicated Arduino library 
currently in development). Six PIDs are requested, three per board:

| PID    | Board       | Mode              |
|--------|-------------|-------------------|
| 0x8380 | Eliobot-S2  | Arduino           |
| 0x8381 | Eliobot-S2  | CircuitPython     |
| 0x8382 | Eliobot-S2  | UF2 Bootloader    |
| 0x8383 | Eliobot-S3  | Arduino           |
| 0x8384 | Eliobot-S3  | CircuitPython     |
| 0x8385 | Eliobot-S3  | UF2 Bootloader    |

### Chip

- Eliobot-S2: **ESP32-S2**
- Eliobot-S3: **ESP32-S3**

### Why a custom PID is needed

CircuitPython requires a unique PID per board to allow the host system to correctly 
identify the device and load the appropriate driver. The UF2 bootloader presents a 
different USB descriptor from the running firmware and therefore also requires its own 
PID. The Arduino firmware similarly requires a dedicated PID for proper host-side 
identification.

### Company

Eliobot — [https://www.eliobot.com](https://www.eliobot.com)
