### PR TITLE
NexusHID - BLE to USB Bridge for PID application

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -906,4 +906,5 @@ PID    | Product name
 0x8382 | Eliobot-S2 - UF2 Bootloader
 0x8383 | Eliobot-S3 - Arduino
 0x8384 | Eliobot-S3 - CircuitPython
-0x8385 | Eliobot-S3 - UF2 Bootloader
+0x8385 | Eliobot-S3 - UF2 BTechnology
+0x8386 | NexusHID - BLE to USB Bridge

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -906,5 +906,5 @@ PID    | Product name
 0x8382 | Eliobot-S2 - UF2 Bootloader
 0x8383 | Eliobot-S3 - Arduino
 0x8384 | Eliobot-S3 - CircuitPython
-0x8385 | Eliobot-S3 - UF2 BTechnology
+0x8385 | Eliobot-S3 - UF2 Bootloader
 0x8386 | NexusHID - BLE to USB Bridge


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->

> I'm making a Bluetooth to USB Bridging device that allows you to connect Bluetooth keyboard and mice to systems that you otherwise couldn't.

> ESP32-S3-LCD-1.47 (USB-A)

> I need a PID because of the custom USB drivers

> It's not ready yet, will be a lot closer with your help ;), but https://nexushid.com