### PR TITLE
Add Scensai Electronic Nose entry to allocated PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -907,5 +907,5 @@ PID    | Product name
 0x8383 | Eliobot-S3 - Arduino
 0x8384 | Eliobot-S3 - CircuitPython
 0x8385 | Eliobot-S3 - UF2 Bootloader
-0x8386 | Scensai Electronic Nose
 0x8386 | NexusHID - BLE to USB Bridge
+0x8387 | Scensai Electronic Nose

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -907,4 +907,5 @@ PID    | Product name
 0x8383 | Eliobot-S3 - Arduino
 0x8384 | Eliobot-S3 - CircuitPython
 0x8385 | Eliobot-S3 - UF2 Bootloader
+0x8386 | Scensai Electronic Nose
 0x8386 | NexusHID - BLE to USB Bridge


### PR DESCRIPTION
We are developing an electronic nose, this is a low-cost gas analyser for various applications in the food and drink industry.

We are using the ESP32-S3-WROOM-1

We need a custom PID for drivers/webserial to filter down to our device correctly.

We're not a company yet, but are hoping to spin out early next year.

Our website is [www.scensai.com](https://scensai.com/).

Thank you!