### PR TITLE
Add PCBCupid Cypher entries to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -909,3 +909,6 @@ PID    | Product name
 0x8385 | Eliobot-S3 - UF2 Bootloader
 0x8386 | NexusHID - BLE to USB Bridge
 0x8387 | Scensai Electronic Nose
+0x8388 | PCBCupid Cypher - Arduino
+0x8389 | PCBCupid Cypher - CircuitPython/MicroPython
+0x838A | PCBCupid Cypher - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -908,7 +908,6 @@ PID    | Product name
 0x8384 | Eliobot-S3 - CircuitPython
 0x8385 | Eliobot-S3 - UF2 Bootloader
 0x8386 | NexusHID - BLE to USB Bridge
-
-0x8388 | PCBCupid Cypher - Arduino
-0x8389 | PCBCupid Cypher - CircuitPython/MicroPython
-0x838A | PCBCupid Cypher - UF2 Bootloader
+0x8387 | PCBCupid Cypher - Arduino
+0x8388 | PCBCupid Cypher - CircuitPython/MicroPython
+0x8389 | PCBCupid Cypher - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -908,3 +908,7 @@ PID    | Product name
 0x8384 | Eliobot-S3 - CircuitPython
 0x8385 | Eliobot-S3 - UF2 Bootloader
 0x8386 | NexusHID - BLE to USB Bridge
+
+0x8388 | PCBCupid Cypher - Arduino
+0x8389 | PCBCupid Cypher - CircuitPython/MicroPython
+0x838A | PCBCupid Cypher - UF2 Bootloader


### PR DESCRIPTION
- Cypher is a usb based development board 
- We are using ESP32S3 MINI N8 
- To auto detect our board in other platform & also to get our boards merged into arduino / circuitpython
- Shop link to purchase the board : https://shop.pcbcupid.com