### PR TITLE
Add 0x838B-0x838D for TMR  devices

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -912,3 +912,6 @@ PID    | Product name
 0x8388 | PCBCupid Cypher - Arduino
 0x8389 | PCBCupid Cypher - CircuitPython/MicroPython
 0x838A | PCBCupid Cypher - UF2 Bootloader
+0x838B | TMR - CAN Interface
+0x838C | TMR - CAN Logger
+0x838D | TMR - GPSdevice


### PR DESCRIPTION
CAN interface is an automotive CAN-bus interface connecting with PC for analysis  and CAN Logger is same kind of system with stand alone logging. GPS device is a GPS device that uses its USB port for configuration and firmware updates. Three PIDs for three hardware models:

- 0x838B: CAN interface
- 0x838C: CAN logger
- 0x838D: GPS device

Chip: ESP32-S3 (all three).

Why a custom PID: our host app identifies devices by VID/PID at enumeration time, so it can tell our units apart from generic ESP32-S3 boards (which share the default PIDs) and pick the right model-specific settings before opening the port. A vendor-specific interface alongside CDC is also planned.

This is an individual/small-batch project; No public product page yet.
