### PR TITLE
Add new Pipo Interfaces entries to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -915,3 +915,6 @@ PID    | Product name
 0x838B | TMR - CAN Interface
 0x838C | TMR - CAN Logger
 0x838D | TMR - GPSdevice
+0x838E | Pipo Interfaces - Pipo Motion
+0x838F | Pipo Interfaces - Pipo Range
+0x8390 | Pipo Interfaces - Pipo Analog


### PR DESCRIPTION
- Pipo Motion, Range, and Analog, are 3 sensing modules meant for creative applications
- Using esp32-s3-mini
- The boards are used as Midi controllers, sometimes simultaneously, and a unique PID is required so that os and music software can properly discriminate between them.

<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->