### PR TITLE
Add 0x8391-0x8395 for AglaiaSense MS500 devices

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -918,3 +918,8 @@ PID    | Product name
 0x838E | Pipo Interfaces - Pipo Motion
 0x838F | Pipo Interfaces - Pipo Range
 0x8390 | Pipo Interfaces - Pipo Analog
+0x8391 | AglaiaSense - MS500 Face
+0x8392 | AglaiaSense - MS500 Gaze
+0x8393 | AglaiaSense - MS500 Pedestrian Detection
+0x8394 | AglaiaSense - MS500 License Plate Recognition
+0x8395 | AglaiaSense - MS500 Traffic


### PR DESCRIPTION
- MS500 Face, Gaze, Pedestrian Detection, License Plate Recognition, and Traffic are AglaiaSense vision devices for edge AI camera applications.

- Using ESP32-P4.

- These devices use USB camera and control interfaces, and separate PIDs are required so host software can properly identify and distinguish each MS500 product variant.

- Company: AglaiaSense