### PR TITLE
Add Work Louder Knob F1 v1 entries to allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -923,3 +923,5 @@ PID    | Product name
 0x8393 | AglaiaSense - MS500 Pedestrian Detection
 0x8394 | AglaiaSense - MS500 License Plate Recognition
 0x8395 | AglaiaSense - MS500 Traffic
+0x8396 | Work Louder - Knob F1 v1 - ANSI
+0x8397 | Work Louder - Knob F1 v1 - ISO


### PR DESCRIPTION
Give a short description of the device and its function

New product collaboration: Framer F1 v1.

Tell us what chip you're using

ESP32-S3

Mention why you need a custom PID

Custom software for Win/Mac that needs to recognize the different products.

If applicable/available mention your company and a link to the website of the product.

https://worklouder.cc/

Let me know how should I update the values to match the other PRs in queue.