### PR TITLE
Allocate 0x8396 for Aethl - NIR Wound Camera (ESP32-P4)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -923,3 +923,4 @@ PID    | Product name
 0x8393 | AglaiaSense - MS500 Pedestrian Detection
 0x8394 | AglaiaSense - MS500 License Plate Recognition
 0x8395 | AglaiaSense - MS500 Traffic
+0x8396 | Aethl - NIR Wound Camera


### PR DESCRIPTION
Requesting the next available PID (0x8396) per the README process.

- **What the device does:** Handheld near-infrared multispectral wound-imaging camera for clinical wound assessment. It streams raw NIR image frames plus acquisition metadata to a host application over USB.

- **Chip:** ESP32-P4

- **Why a custom PID:** The device exposes a vendor-specific (class 0xFF) bulk interface consumed via WinUSB/WebUSB on the host, not a standard TinyUSB class/driver pairing, so the default TinyUSB PIDs don't apply. A stable unique PID is also required so hospital IT departments can identify and allowlist the device by VID/PID in managed-browser device-access policies (Chrome/Edge WebUSB / Web Serial URL allowlists) and endpoint USB-control software.

- **Company:** Aethl (https://aethl.com) — product site: https://woundsight.ai (in development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)