### PR TITLE
Allocate 0x8398 for a handheld NIR multispectral camera (ESP32-P4)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -925,3 +925,4 @@ PID    | Product name
 0x8395 | AglaiaSense - MS500 Traffic
 0x8396 | Work Louder - Knob F1 v1 - ANSI
 0x8397 | Work Louder - Knob F1 v1 - ISO
+0x8398 | Handheld NIR multispectral camera


### PR DESCRIPTION
Requesting the next available PID per the README.

- Device: a handheld near-infrared multispectral camera that streams image frames to a host application over USB.
- Chip: ESP32-P4
- Why a custom PID: the device exposes a vendor-specific (class 0xFF) bulk interface used via WinUSB/WebUSB rather than a standard TinyUSB class/driver, so the default TinyUSB PIDs don't apply. A stable, unique PID also lets IT departments identify and allow-list the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)