### PR TITLE
Add PID 0x8399 for VTR Effects Sanctum Reverb - Platinum Series

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -925,3 +925,4 @@ PID    | Product name
 0x8395 | AglaiaSense - MS500 Traffic
 0x8396 | Work Louder - Knob F1 v1 - ANSI
 0x8397 | Work Louder - Knob F1 v1 - ISO
+0x8370 | Sanctum Reverb - Platinum Series - VTR Effects


### PR DESCRIPTION
…Reverb - Platinum Serieslocated-pids.txt

**Description:** Sanctum Reverb is a boutique digital reverb guitar pedal, part of VTR Effects' Platinum Series. The USB interface is used for firmware updates, preset management, and parameter control via our VTRStudio desktop application over USB CDC.
**Chip:** ESP32-S3

**Why a custom PID:** The device uses a custom CDC protocol for firmware updates and parameter control, requiring a unique PID so our desktop software can reliably identify each product model. We already maintain PIDs 0x81A4-0x81A8, 0x81D7, 0x81E5, 0x82F7 and 0x82F8 under the Espressif VID.

**Company:** VTR Electronics Audio Ltda (VTR Effects) - https://vtreffects.com.br
