### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -925,3 +925,4 @@ PID    | Product name
 0x8395 | AglaiaSense - MS500 Traffic
 0x8396 | Work Louder - Knob F1 v1 - ANSI
 0x8397 | Work Louder - Knob F1 v1 - ISO
+0x8398 | Mushroom Soft - Mushroom Radio Module


### PR DESCRIPTION
Device: Mushroom Radio Module – a USB CDC device for radio communication, based on ESP32-S3.

Final hardware: ESP32-S3-WROOM-1 (N8R8). Currently testing on ESP32-S3 Super Mini.

Vendor: Mushroom Soft.

Website: https://maximus-messanger.netlify.app (note: "Maximus" is a temporary project name; the final name will be "Mushroom" once the website is updated).

Purpose: This custom PID is required to uniquely identify the device in the companion Windows application (C#). The standard TinyUSB PID does not allow reliable device detection, as multiple ESP32-S3 devices may be connected simultaneously.

Chip: ESP32-S3.

USB Class: CDC (Communications Device Class) – virtual COM port.

Additional context: The device will be used for radio data exchange with a PC application. The custom PID ensures that the application can distinguish this device from other ESP32-S3 boards.

Give me PID 0x8398 or 0x8399 or any other please

0x8398 | Mushroom Soft - Mushroom Radio Module

<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->