### PR TITLE
Add PID 0x839A for Pico View

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -927,3 +927,4 @@ PID    | Product name
 0x8397 | Work Louder - Knob F1 v1 - ISO
 0x8398 | Handheld NIR multispectral camera
 0x8399 | Sanctum Reverb - Platinum Series - VTR Effects
+0x839A | PicoView


### PR DESCRIPTION
**Description:** Pico View is an ESP32-P4 USB-HS display bridge for a capacitive-touch LCD panels. It transmits the application's real-time UI via USB HS, receives touchscreen feedback, and interact with peripherals (sensors, LRAs).

**Chip:** ESP32-P4

**Why a custom PID:** The device uses a custom protocol to stream the UI, interact with peripherals and firmware OTA update. And requiring a unique PID so our desktop software (NanoDash) can reliably identify the device.

**Website:** https://nanoda.sh/  