### PR TITLE
Add NXI - LyriX Remote and Extender to allocated PIDs

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -927,3 +927,5 @@ PID    | Product name
 0x8397 | Work Louder - Knob F1 v1 - ISO
 0x8398 | Handheld NIR multispectral camera
 0x8399 | Sanctum Reverb - Platinum Series - VTR Effects
+0x839A | NXI - LyriX Remote
+0x839B | NXI - LyriX Extender


### PR DESCRIPTION
### Device description
LyriX Remote and LyriX Extender are companion devices in the LyriX product line, used for: LyriX Remote - remote controller for the whole LyriX system (communicates with RPi), LyriX Extender - extending the range of the LyriX system where RPi AP is weak. LyriX is song-displaying system for music bands, churches...

### Chip
ESP32-S3

### Reason for custom PID
We need unique PIDs to allow our host software to automatically identify and distinguish between different LyriX devices (Remote and Extender) when connected via USB. LyriX Remote can be updated both via OTA and USB and LyriX Extender is configured via USB (secrets like WiFi SSID and password).

### Company link
https://www.nxi.sk/

### Product links
LyriX System: https://www.nxi.sk/lyrix/
LyriX Remote: https://www.nxi.sk/lyrix/products/lyrix-remote.php
LyriX Extender: https://www.nxi.sk/lyrix/products/lyrix-extender.php

### Company
NXI, s. r. o.
Kukucinova 22
974 01 Banska Bystrica
Slovakia