### PR TITLE
Add PalmBlock DexoPad PID

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -928,3 +928,4 @@ PID    | Product name
 0x8398 | Handheld NIR multispectral camera
 0x8399 | Sanctum Reverb - Platinum Series - VTR Effects
 0x839A | PicoView
+0x839B | PalmBlock Technology - DexoPad


### PR DESCRIPTION
### Device description

DexoPad is an ESP32-S3-based USB device from PalmBlock Technology Co., Ltd. It is designed as a compact remote-control and input device for desktop/mobile workflows, exposing USB HID functions such as keyboard and mouse control together with a CDC serial interface used by the companion software, factory provisioning/flashing tools, and diagnostics.

The product information page is available at:

https://www.dexopad.com/

### Chip

ESP32-S3

### USB classes

Composite USB device using standard HID and CDC interfaces.

### Reason for a custom PID

DexoPad currently uses the generic Arduino-ESP32 TinyUSB VID/PID `0x303A:0x1001`, which is shared by many ESP32-S3 devices. A dedicated PID is needed so the DexoPad companion application, manufacturing/flashing tools, and support diagnostics can reliably distinguish DexoPad from unrelated ESP32-S3 boards or other TinyUSB-based devices when multiple USB devices are connected.

Using a product-specific PID also lets host-side software select the correct device before opening the HID/CDC interfaces, avoiding accidental input/control actions or provisioning steps being applied to the wrong ESP32-S3 device.

### Company

PalmBlock Technology Co., Ltd.

### Product information

https://www.dexopad.com/

### Requested PID

`0x839B` for PalmBlock Technology - DexoPad.

I am happy to rebase or adjust the requested PID if another pending request is merged first.