### PR TITLE
Allocate PID 0x839C-0x839E for Waveshare ESP32-S3-ETH-8DI-8RO-C

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -929,3 +929,6 @@ PID    | Product name
 0x8399 | Sanctum Reverb - Platinum Series - VTR Effects
 0x839A | PicoView
 0x839B | PalmBlock Technology - DexoPad
+0x839C | Waveshare ESP32-S3-ETH-8DI-8RO-C - Arduino
+0x839D | Waveshare ESP32-S3-ETH-8DI-8RO-C - CircuitPython
+0x839E | Waveshare ESP32-S3-ETH-8DI-8RO-C - UF2 Bootloader


### PR DESCRIPTION
- **Device description**: Industrial relay/CAN controller with 8 isolated
  digital inputs, 8 relay outputs (TCA9554 expander), W5500 Ethernet, buzzer,
  NeoPixel, SD card, and PCF85063 RTC.
- **Chip**: ESP32-S3-WROOM-1-N16R8
- **Why a custom PID**: This is a unique board with a completely different
  peripheral set and pin map from the existing Waveshare ESP32-S3-ETH. It needs
  its own PID so Arduino-ESP32 and Arduino IDE, CircuitPython's build system and circuitpython.org can
  distinguish it and serve the correct firmware.
- **Company/Individual**: Individual contributor, adding CircuitPython and Arduino support
  for this Waveshare board.
- **Product URL**: https://www.waveshare.com/esp32-s3-eth-8di-8ro-c.htm

note - I've noticed there is 1 waiting PR so I've pre-emptively requested 0x839C-0x839E. I will rebase when merges proceed.