### PR TITLE
Add LumiLynx 16P to allocated PIDs list

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -932,3 +932,4 @@ PID    | Product name
 0x839C | Waveshare ESP32-S3-ETH-8DI-8RO-C - Arduino
 0x839D | Waveshare ESP32-S3-ETH-8DI-8RO-C - CircuitPython
 0x839E | Waveshare ESP32-S3-ETH-8DI-8RO-C - UF2 Bootloader
+0x839F | LumiLynx 16P


### PR DESCRIPTION
**Description**:
The LumiLynx 16P is an LED controller that can control 16 channels of addressable LEDs via a high speed USB connection to a host computer.

**Chip**:
ESP32-P4

**Reason for a custom chip**:
The firmware can be updated by the user through a web interface. We cannot risk a user wiping another device who happens to be plugged in and share the same PID. 

**Company**:

The company is LumiLynx. The creator is myself: [djipco](https://github.com/djipco). The company's website is not ready yet but it will be hosted at lumilynx.ca (which I already registered). The firmware will implement my new Opalinx protocol, which is [publicly available](https://github.com/djipco/opalinx-spec).


