### PR TITLE
Add PID 0x83A0 for Skillado Display SK-D1

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -933,3 +933,4 @@ PID    | Product name
 0x839D | Waveshare ESP32-S3-ETH-8DI-8RO-C - CircuitPython
 0x839E | Waveshare ESP32-S3-ETH-8DI-8RO-C - UF2 Bootloader
 0x839F | LumiLynx 16P
+0x83A0 | Skillado Display - SK-D1


### PR DESCRIPTION
## Device
Skillado Display - SK-D1 is a 5-inch USB telemetry and configuration display for a force-feedback steering wheel and racing simulator peripherals. It can work standalone over USB with Central do Volante Skillado and as a modular display over RS-485 when attached to the Skillado base/wheel ecosystem.

## Chip
ESP32-S3 (Waveshare ESP32-S3-Touch-LCD-5)

## Why a custom PID is needed
The custom PID lets Central do Volante Skillado uniquely identify the SK-D1 among other Skillado USB devices and peripherals, select product-specific configuration and firmware-update paths, and avoid relying on a generic TinyUSB PID shared with unrelated devices.

## Company
Skillado

## Website
http://skillado.pedrovacari.com.br/