### PR TITLE
Allocate PIDs 0x83A1-0x83A3 for Waveshare ESP32-S3-ETH-8DI-8RO (RS485 version)

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -934,3 +934,6 @@ PID    | Product name
 0x839E | Waveshare ESP32-S3-ETH-8DI-8RO-C - UF2 Bootloader
 0x839F | LumiLynx 16P
 0x83A0 | Skillado Display - SK-D1
+0x83A1 | Waveshare ESP32-S3-ETH-8DI-8RO - Arduino
+0x83A2 | Waveshare ESP32-S3-ETH-8DI-8RO - CircuitPython
+0x83A3 | Waveshare ESP32-S3-ETH-8DI-8RO - UF2 Bootloader


### PR DESCRIPTION
- **Device description**: Industrial relay/RS485 controller with 8 isolated
  digital inputs, 8 relay outputs (TCA9554 expander), W5500 Ethernet, buzzer,
  NeoPixel, SD card, and PCF85063 RTC.
- **Chip**: ESP32-S3-WROOM-1-N16R8
- **Why a custom PID**: This device is similar to https://github.com/espressif/usb-pids/pull/341, but has an rs485 module attached to the UART, and so must be recognized as different to serve different example code and hardware presets by Arduino & circuitpython
- **Company/Individual**: Individual contributor, adding CircuitPython and Arduino support
  for this Waveshare board.
- **Product URL**: https://www.waveshare.com/esp32-s3-eth-8di-8ro.htm