### PR TITLE
Add PID 0x83A4 for Fargo Engineering FB1000 CAN RLU

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -939,3 +939,4 @@ PID    | Product name
 0x83A3 | Waveshare ESP32-S3-ETH-8DI-8RO - UF2 Bootloader
 0x83A4 | NXI - LyriX Remote
 0x83A5 | NXI - LyriX Extender
+0x83A6 | Fargo Engineering FB1000 CAN RLU


### PR DESCRIPTION
Requesting PID **0x83A4** under the Espressif VID — next sequential entry in `allocated-pids.txt` (CI format check passes locally).

- **What the device does:** The FB1000 is a wireless CAN (J1939) diagnostic logger. Its "FEI-RLU" firmware personality exposes a USB **CDC-ACM** serial port that a Windows desktop app (C#) connects to in order to download stored fault-code / VIN / driveline-hours logs from the device.
- **Chip:** ESP32-S3 (ESP32-S3-WROOM-1U-N16R8), native USB.
- **Why a custom PID:** to give the product a stable USB identity distinct from the generic default TinyUSB CDC PID, so the host application can reliably auto-select the correct FB1000 unit when several ESP32-based USB devices are on the same PC. The device is matched by VID:PID plus a per-unit MAC-derived `iSerialNumber`. We use the standard CDC-ACM class (inbox `usbser.sys`) — the custom PID is for product identification, not a custom driver.
- **Company:** Fargo Engineering Inc.
- **URL:** https://www.fargoengineering.com
