### PR TITLE
Add 0x83A6 for LHR - USB LIN Box

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -940,3 +940,4 @@ PID    | Product name
 0x83A4 | NXI - LyriX Remote
 0x83A5 | NXI - LyriX Extender
 0x83A6 | Fargo Engineering FB1000 CAN RLU
+0x83A7 | LHR - USB LIN Box


### PR DESCRIPTION
Adding PID **0x83A6** for **LHR - USB LIN Box**.

- **Device description**: A USB-to-LIN bridge device for debugging the LIN
  (Local Interconnect Network) protocol commonly used in the automotive
  industry. The device exposes two independent LIN master channels over a USB
  Vendor Bulk endpoint using a simple text line protocol, and lets a host PC
  application drive LIN transactions (Begin/End, MasterRequest, SlaveResponse,
  Status) for automotive LIN bus testing and diagnostics.

- **Chip**: ESP32-S3 (using its native USB OTG peripheral).

- **Why a custom PID**: The device uses a custom USB Vendor class with a
  proprietary line-based command protocol over Bulk endpoints, requiring a
  custom host-side driver stack (WinUSB on Windows, libusb on Linux/macOS)
  rather than any standard TinyUSB class. The default TinyUSB Vendor-class PID
  is therefore not appropriate — a distinct PID is needed so the host can bind
  to the correct driver and locate the device unambiguously.

- **Individual / company**: Requesting as an individual maker (GitHub:
  @lhrbu). Not on behalf of a company.

- **Product URL**: Firmware repository —
  https://gitee.com/lhrbu/lhr_esp32s3_usb_bulk
  Host SDK repository — https://gitee.com/lhrbu/LHR.USBLIN
