### PR TITLE
Add new PID for ZEuON - Link G8

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -939,3 +939,4 @@ PID    | Product name
 0x83A3 | Waveshare ESP32-S3-ETH-8DI-8RO - UF2 Bootloader
 0x83A4 | NXI - LyriX Remote
 0x83A5 | NXI - LyriX Extender
+0x83A6 | ZEuON - Link G8


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->

- Device Description: USB interface for Link G8 device
- Chip used: ESP32-S2
- Why custom PID is needed: For non-standard custom driver communication
- Company name: ZEuON Inc
