### PR TITLE
Add new PID for ZEuON - Link G8

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -941,3 +941,4 @@ PID    | Product name
 0x83A5 | NXI - LyriX Extender
 0x83A6 | Fargo Engineering FB1000 CAN RLU
 0x83A7 | LHR - USB LIN Box
+0x83A8 | ZEuON - Link G8


### PR DESCRIPTION
- Short description: (예: USB communication adapter for ZEuON devices)
- Chip used: (예: ESP32-S3 또는 ESP32-S2 등 실제 사용 중인 칩 모델 기재)
- Why custom PID is needed: (예: Device needs custom host application communication)
- Company name: ZEuON Inc.
- Product/Company URL: (없다면 N/A 혹은 회사 홈페이지 링크 기재)
