### PR TITLE
Add new PID for ZEuON - Link G8

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -941,3 +941,4 @@ PID    | Product name
 0x83A5 | NXI - LyriX Extender
 0x83A6 | Fargo Engineering FB1000 CAN RLU
 0x83A7 | LHR - USB LIN Box
+0x83A8 | ZEuON - Link G8


### PR DESCRIPTION
Add a customer-allocated USB PID (0x83A8) for ZEuON Link G8 device under the Espressif VID.


- Short description: USB communication adapter for ZEuON devices.
- Chip used: ESP32-S2
- Why custom PID is needed: The device requires custom host application communication and non-standard drivers.
- Company name: ZEuON Inc.
- Product/Company URL: N/A
