### PR TITLE
Add 0x83A9 for Fujian CxPerfect Technology - USB Earphone Adapter Cable

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -942,3 +942,4 @@ PID    | Product name
 0x83A6 | Fargo Engineering FB1000 CAN RLU
 0x83A7 | LHR - USB LIN Box
 0x83A8 | ZEuON - Link G8
+0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable


### PR DESCRIPTION
Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
USB earphone adapter cable — a USB-to-3.5mm audio adapter/dongle that presents a USB audio interface to the host and outputs analog audio to an earphone/headphone jack.

- Tell us what chip you're using, 
- ESP32-P4
- Mention why you need a custom PID
- The device implements a USB Audio Class (UAC) interface. We need a custom PID so the host OS/drivers identify the device uniquely as our own product (Fujian CxPerfect Technology) rather than presenting with the generic TinyUSB default PID shared by many devices.
- If applicable/available mention your company and a link to the website of the product.
Fujian CxPerfect Technology Co., Ltd (福建创芯飞特科技有限公司)
