### PR TITLE
Allocate PID 0x83AA for BurnSlap FAV-EQ

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -943,3 +943,4 @@ PID    | Product name
 0x83A7 | LHR - USB LIN Box
 0x83A8 | ZEuON - Link G8
 0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable
+0x83AA | BurnSlap - FAV-EQ


### PR DESCRIPTION
<Device description>
FAV-EQ is a commercial ferrofluid audio visualizer manufactured and sold by BurnSlap. It visualizes audio signals by controlling an electromagnet that moves ferrofluid.

The USB interface provides CDC serial communication, DFU support, and a Mass Storage Class interface for firmware updates and usage-log access.

<Chip>
ESP32-S3, contained in the u-blox NORA-W106 module on the Arduino Nano ESP32.

<Reason for requesting a custom PID>
FAV-EQ is a finished commercial product rather than a general-purpose Arduino development board. It requires a stable product-specific USB identity so that customer computers recognize it as “BurnSlap FAV-EQ” instead of “Arduino Nano ESP32.”

The default Arduino Nano ESP32 VID/PID is therefore not suitable for the production version of the product.

<Company>
BurnSlap

<Website>
https://burnslap.me