### PR TITLE
Allocate PID 0x83AB for IMSHOX - OX SENTINEL KEY - FIDO/HSM

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -944,3 +944,4 @@ PID    | Product name
 0x83A8 | ZEuON - Link G8
 0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable
 0x83AA | BurnSlap - FAV-EQ
+0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM


### PR DESCRIPTION
Hi Espressif team,

I'd like to request a PID for my project, the **OX SENTINEL KEY**.

**Device description:**
The OX SENTINEL KEY is a FIDO security key combined with an HSM (Hardware Security Module) built on the ESP32-S3. It provides:
- FIDO2 / WebAuthn authentication (CTAP2 protocol over USB)
- HSM functionality (cryptographic key storage, signing, decryption via APDU interface)
- WebUSB interface for browser-based configuration and management
- WebCCID interface for smart-card style communication

**Chip used:** ESP32-S3

**Why a custom PID is needed:**
The device exposes custom composite USB interfaces (FIDO CTAP + HSM APDU + WebUSB + WebCCID) that are not covered by TinyUSB's default pre-allocated PIDs. A dedicated PID is required so host drivers and browser APIs can correctly identify the device.

**Requested by:** IMSHOX (individual developer)

**PID requested:** 0x83AA (next available after 0x83A9)