### PR TITLE
Add new PID for FloatStone DualNet DMX4

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -943,3 +943,4 @@ PID    | Product name
 0x83A7 | LHR - USB LIN Box
 0x83A8 | ZEuON - Link G8
 0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable
+0x83AA | FloatStone - DualNet DMX4


### PR DESCRIPTION
Please answer the questions in the README.md of this repo: 
Request PID 0x83AA under Espressif VID 0x303A.
Company: ShenZhen FloatStone tec
Product: DualNet DMX4
USB function: USB NCM network adapter
Chip: ESP32-P4
new product, not released