### PR TITLE
Add PID 0x83AA for STRATA Flasher V2

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -943,3 +943,4 @@ PID    | Product name
 0x83A7 | LHR - USB LIN Box
 0x83A8 | ZEuON - Link G8
 0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable
+0x83AA | STRATA Flasher V2


### PR DESCRIPTION
**Device description**
STRATA Flasher V2 is an OBD-II ECU diagnostic and reprogramming interface. It presents a USB CDC-ACM
interface to a Windows host, where a J2534 PassThru DLL drives it to perform UDS/KWP2000
diagnostics and firmware flashing over CAN, CAN FD and K-Line.

**Espressif chip**
ESP32-S3 (ESP32-S3-WROOM-1-N16R8), using the native USB OTG peripheral.

**Why a dedicated PID rather than the default**
The device ships with a J2534 DLL that must locate its own hardware among any other USB serial
devices present. J2534 client applications and Windows driver binding both key on VID/PID, so a
PID shared with every other ESP32 CDC device is not sufficient to identify this product reliably.

**Company**
STRATA