### PR TITLE
Allocate 0x83AB — Order of the Dice Technology Vision Dice Tower

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -944,3 +944,4 @@ PID    | Product name
 0x83A8 | ZEuON - Link G8
 0x83A9 | Fujian CxPerfect Technology Co., Ltd - USB Earphone Adapter Cable
 0x83AA | BurnSlap - FAV-EQ
+0x83AB | Order of the Dice Technology Vision Dice Tower


### PR DESCRIPTION
A short description of what the device is going to do:
Vision Dice Tower — a tabletop-gaming dice tower with an integrated
camera. The device presents a USB composite interface: UVC video
(camera stream of the dice tray) + CDC-ACM (roll-trigger events and
device control). A host application reads die results from the video
and injects them into virtual tabletop software.

What chip are you using for the device the PID is allocated for:
ESP32-P4

Why you need a custom PID:
Commercial product (Kickstarter-funded production run). We need a
unique, stable VID/PID identity so Windows driver bindings and device
metadata are specific to our product rather than shared with devices
using the TinyUSB/example defaults, and for per-product identification
in support and compliance contexts.

Company: Order of the Dice Technology LLC
URL: https://www.orderofthedice.com