### PR TITLE
:Allocate PID 0x83AD for KeyLock - Smart Security USB Device

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,3 +946,4 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
+0x83AD | Meng Qingyao - KeyLock smart security USB device


### PR DESCRIPTION
:KeyLock smart security USB device (scan-code login replacement + password vault). ESP32-C5, custom vendor
  class (usage page 0xFF00) + HID + CDC composite. Requested by Meng Qingyao.