### PR TITLE
Added Inbrat PVSense PID

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,3 +946,4 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
+0x83AD | INBRAT - PVSense


### PR DESCRIPTION
**- Give a short description of the device and its function:**
This is a solar irradiance meter.
**- Tell us what chip you're using:**
This device is based on the ESP32-S3 chip.
**- Mention why you need a custom PID:**
This device uses USB communication to extract log data and require custom PIDs so that the log extraction software can automatically detect the USB connection, identify which device is connected, and handle the communication accordingly.
**- If applicable/available mention your company and a link to the website of the product:**
[Inbrat](https://inbrat.com.br/)