### PR TITLE
Update allocated-pids.txt: AL-KO VT

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,3 +946,5 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
+0x83AD | AL-KO VT - Mammut Galaxy: Remote Control
+0x83AE | AL-KO VT - Mammut Galaxy: Central Control Unit


### PR DESCRIPTION
Added our two PIDs to the list

-	A short description of what the device is going to do (e.g. cat tracker with USB trace download)
**o	Wireless remote-controlled maneuvering system for trailers and caravans. "Mammut Galaxy" is the system which contains a remote control, as well as a central control unit. Both sub-devices of the system have a seperate ESP**

-	What chip are you using for the device the PID is allocated for (e.g. ESP32-S2)
**o	Central Control Unit: ESP32-C6-MINI-1** 
**o	Remote Control: ESP32-S3-WROOM-1** 

-	Why you need a custom PID (and can't, for instance, use the default TinyUSB PIDs)
**o	Use a custom USB stack, because only usage of individual pairing via cable**

-	If applicable/available, a website or other URL with information about your product or company
**o	Company URL: https://www.alko-tech.com/en**
**o	Alois Kober GmbH (Brand name: AL-KO VT)**
