### PR TITLE
Allocate PID for Opzaro Security FIDO2 Authenticator

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,4 +946,4 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
-0x83AE | Opzaro Security - FIDO2 Authenticator
+0x83B0 | Opzaro Security - FIDO2 Authenticator

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,4 +946,4 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
-0x83AD | Opzaro Security - FIDO2 Authenticator
+0x83AE | Opzaro Security - FIDO2 Authenticator

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -946,3 +946,4 @@ PID    | Product name
 0x83AA | BurnSlap - FAV-EQ
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
+0x83AD | Opzaro Security - FIDO2 Authenticator


### PR DESCRIPTION
## Product

Opzaro Security - FIDO2 Authenticator

## Description

A commercially distributed USB FIDO2/WebAuthn hardware security authenticator.

## Espressif chip

ESP32-S3 using its native USB-OTG interface.

## Reason for requesting a dedicated PID

The product requires a stable and unique USB identity for enterprise device inventory, VID/PID allow-listing, firmware compatibility, management utilities and support diagnostics.

The shared TinyUSB HID PID identifies the enabled USB class configuration but cannot uniquely distinguish this commercial security-key product from unrelated TinyUSB HID devices.

The device uses the standard USB HID FIDO usage page and the operating system's standard HID driver. No custom Windows driver is required.

## Company

Opzaro Security

## Website

https://www.opzaro.com
