### PR TITLE
Add EMC PARTNER ESDEX FIBRE ADAPTER

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -950,3 +950,4 @@ PID    | Product name
 0x83AE | KiraLive - DFU
 0x83AF | Banana Ramble, LLC - AutoDecode
 0x83B0 | Opzaro Security - FIDO2 Authenticator
+0x83B1 | EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX


### PR DESCRIPTION
Requesting PID allocation for ESP32-S3 commercial product

**Product**

EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX

**Function**

USB fiber-to-serial adapter for the EMC PARTNER ESDEX ESD generator. Used by the configuration tool for device detection and serial communication.

**Chip**

ESP32-S3

**Reason for custom PID:**

The configuration tool identifies this accessory by USB PID. A unique PID is required so it can correctly detect the Fibre Adapter and distinguish it from the ESDEX generator (already allocated as 0x8342) and from other CDC serial devices. TinyUSB default PIDs cannot be used in production due to potential collisions with other devices.

**Company**

EMC PARTNER AG
Website: www.emc-partner.com

This PID will be used exclusively for this product.

Thank you.