### PR TITLE
Add PID for PROSARIS - PULSE

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -951,3 +951,4 @@ PID    | Product name
 0x83AF | Banana Ramble, LLC - AutoDecode
 0x83B0 | Opzaro Security - FIDO2 Authenticator
 0x83B1 | EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX
+0x83B2 | PROSARIS - PULSE


### PR DESCRIPTION
**Device:** Prosaris Pulse — a sensor that captures ultrasonic data for
industrial reliability and maintenance work.

**Chip:** ESP32-S3

**Why a custom PID:** The device enumerates as a custom composite UAC
microphone + CDC, not stock TinyUSB descriptors, so the class-default PID
is not appropriate. Various host applications need to distinguish our
product from other TinyUSB devices — a shared class-default PID makes the
unit indistinguishable in host port selection and risks driver-binding
collisions with unrelated devices presenting a different interface layout
under the same VID:PID.

**Company:** Prosaris — https://www.prosaris.ca/