### PR TITLE
Request pid for KiraLive dfu

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -947,3 +947,4 @@ PID    | Product name
 0x83AB | IMSHOX - OX SENTINEL KEY - FIDO/HSM
 0x83AC | FloatStone - DualNet DMX4
 0x83AD | INBRAT - PVSense
+0x83AE | KiraLive - DFU


### PR DESCRIPTION
Requesting PID allocation for the KiraLive-DFU so can use non-standard driver for update fw.

Chip: ESP32-S3

Description: use pid with custom usb device so we can use non-standard driver to update fw.

WebSite: http://kirakira.tv/