### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -745,7 +745,7 @@ PID    | Product name
 0x82E1 | Unexpected Maker SQUiXL - UF2 Bootloader
 0x82E2 | Dilon Tech Probe (ESP32 S3)
 0x82E3 | Work Louder - Knob v1 - ISO
-0x82E4 | Domino4 - CWS - Springbot (ESP32-S2) - UF2 Bootloader
+0x82E4 | Domino4 - CWS - Springbot (ESP32-S3)
 0x82E5 | FED4 - Arduino
 0x82E6 | FED4 - CircuitPython
 0x82E7 | FED4 - Uf2 Bootloader


### PR DESCRIPTION
Changed the description on 0x82E4 from esp32-s2 to -s3, and removed "uf2 bootloader". Hardware has been upgraded to s3, before releasing the development board.


<!-- Please answer the questions in the README.md of this repo: 
- Educational development board with on-board sensors and connectors to domino4's eco-system
- ESP32-S3FN8
- Already got the PID, just updating the description.
- Company is domino4, and description of product can be found here: http://domino4.com/CWS
-->