### PR TITLE
Allocate PID 0x83B3 for AmphiLink

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -952,3 +952,4 @@ PID    | Product name
 0x83B0 | Opzaro Security - FIDO2 Authenticator
 0x83B1 | EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX
 0x83B2 | PROSARIS - PULSE
+0x83B3 | danjinghaoeggggg - AmphiLink


### PR DESCRIPTION
## Device description

AmphiLink is a wired and wireless CMSIS-DAP v2 debug probe based on the ESP32-S3.

In wired mode, it provides SWD debugging and target reset through the ESP32-S3 native USB interface. In wireless mode, it provides CMSIS-DAP communication over Wi-Fi using OpenOCD's CMSIS-DAP TCP backend.

## Espressif chip

ESP32-S3 N16R8 module, using the ESP32-S3 native USB peripheral.

## Reason for requiring a custom PID

AmphiLink implements CMSIS-DAP v2 using a vendor-specific USB interface with bulk IN and OUT endpoints rather than a standard USB device class.

On Windows, Microsoft OS 2.0 descriptors are used to associate the vendor-specific interface with WinUSB. A dedicated PID is therefore required for stable product identification and host-side device/driver association. The generic TinyUSB example/default PID is not appropriate for distributing this product.

## Applicant

This PID is requested for an individual project by `danjinghaoeggggg`. It is not requested on behalf of a company.

## Project availability

The project is currently under active development and its source repository is not publicly available yet. It is planned to be open-sourced in the near future.

## Requested USB ID

- VID: `0x303A` (Espressif)
- PID: `0x83B3`
- Product: `danjinghaoeggggg - AmphiLink`