### PR TITLE
Allocate PIDs for Pixelcade Sidekick display family

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -953,3 +953,8 @@ PID    | Product name
 0x83B1 | EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX
 0x83B2 | PROSARIS - PULSE
 0x83B3 | danjinghaoeggggg - AmphiLink
+0x83B4 | Pixelcade Sidekick AMOLED 1.91"
+0x83B5 | Pixelcade Sidekick 2.8"
+0x83B6 | Pixelcade Sidekick 3.5"
+0x83B7 | Pixelcade Sidekick 5"
+0x83B8 | Pixelcade Sidekick 7"


### PR DESCRIPTION
Requesting 6 sequential PIDs under Espressif's VID (0x303A) for the Pixelcade Sidekick product line -- USB-connected companion display boards for arcade cabinets. First 5 are ESP32-S3 (native USB/TinyUSB); the 6th (Tab5) is ESP32-P4, also native USB.

- 0x83B4 | Pixelcade Sidekick AMOLED 1.91"
- 0x83B5 | Pixelcade Sidekick 2.8"
- 0x83B6 | Pixelcade Sidekick 3.5"
- 0x83B7 | Pixelcade Sidekick 5"
- 0x83B8 | Pixelcade Sidekick 7"
- 0x83B9 | Pixelcade Sidekick 5" Tab5