### PR TITLE
Add PID 0x83B4 for VTR Effects Imago Delay - Platinum SeriesAdd PID 0x83B4 for VTR Effects Imago Delay - Platinum Series

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -953,3 +953,4 @@ PID    | Product name
 0x83B1 | EMC PARTNER ESDEX FIBRE ADAPTER - Fiber to serial adapter for ESDEX
 0x83B2 | PROSARIS - PULSE
 0x83B3 | danjinghaoeggggg - AmphiLink
+0x83B4 | Imago Delay - Platinum Series - VTR Effects


### PR DESCRIPTION
<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->**Description:** Imago Delay is a boutique digital delay guitar pedal, part of VTR Effects' Platinum Series. The USB interface is used for firmware updates, preset management, and parameter control via our VTRStudio desktop application over USB CDC.

**Chip:** ESP32-S3

**Why a custom PID:** The device uses a custom CDC protocol for firmware updates and parameter control, requiring a unique PID so our desktop software can reliably identify each product model. We already maintain PIDs 0x81A4-0x81A8, 0x81D7, 0x81E5, 0x82F7, 0x82F8 and 0x8399 under the Espressif VID.

**Company:** VTR Electronics Audio Ltda (VTR Effects) - https://vtreffects.com.br