### PR TITLE
Add new PID entry for PAUSCH-e Midi-Matrix-Scanner

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -955,3 +955,4 @@ PID    | Product name
 0x83B3 | danjinghaoeggggg - AmphiLink
 0x83B4 | Imago Delay - Platinum Series - VTR Effects
 0x83B5 | ESSOTEC - XENPAD Omni programmable macropad with display
+0x83B6 | PAUSCH-e - Midi-Matrix-Scanner 1 MAN


### PR DESCRIPTION
The device scanns an keyboard matrix and gives the midi over USB to an PC We work with the ESP32S3 Zero Board
We develop a few different boards with this chip and it is more shure if there are more devices on one PC Our company is [www.PAUSCH-e.com](http://www.pausch-e.com/)

Device description:
MIDI matrix scanner for reading keyboard matrix inputs and sending the data over USB.

Chip used:
ESP32-S3

Reason for custom PID:
A custom PID is needed so the device can be identified as a separate USB product because we develope a few boards with ESP32S3 with different functins for the same PC.

Company:
PAUSCH-e, Günter Pausch

Website:
[www.pausch-e.com](http://www.pausch-e.com/)