### PR TITLE
Add ZEuON Link G9 to allocated PIDs list

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -957,3 +957,4 @@ PID    | Product name
 0x83B5 | ESSOTEC - XENPAD Omni programmable macropad with display
 0x83B6 | BUCH.IT - APEX Vision Camera Module
 0x83B7 | BUCH.IT - APEX Vision Camera Module CAN-Bus Interface
+0x83B8 | ZEuON - Link G9

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -957,4 +957,4 @@ PID    | Product name
 0x83B5 | ESSOTEC - XENPAD Omni programmable macropad with display
 0x83B6 | BUCH.IT - APEX Vision Camera Module
 0x83B7 | BUCH.IT - APEX Vision Camera Module CAN-Bus Interface
-0x83B8 | ZEuON - Link G9
+0x83B8 | ZEuON.com - Link G9


### PR DESCRIPTION
- Allocated PID: 0x83B8
- Vendor: ZEuON.com
- Product: Link G9
- Chip: ESP32-S2

This commit registers a new product ID under Espressif's VID (0x303A) for our upcoming ESP32-S2 based device, "Link G9".


<!-- Please answer the questions in the README.md of this repo: 
- Give a short description of the device and its function, 
- Tell us what chip you're using, 
- Mention why you need a custom PID
- If applicable/available mention your company and a link to the website of the product.
-->